### PR TITLE
don't assume log stream is stopped until the firmware sends an ack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ matrix:
           packages:
             - g++-6
             - gcc-6
-            - python-pip
+            - python3-pip
 
 before_script:
-        - pip install --user future pymavlink
+        - pip3 install --user future pymavlink
         - CXX="g++-6"
         - CC="gcc-6"
 
 script:
         - ./autogen.sh c --with-systemdsystemunitdir=/usr/lib/systemd/system
         - make -j
-        - make check
+        - make check PYTHON=python3

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ clean-local:
 	rm -f $(top_builddir)/tests/unit_test
 
 include/mavlink/ardupilotmega/mavlink.h: modules/mavlink/pymavlink/tools/mavgen.py modules/mavlink/message_definitions/v1.0/ardupilotmega.xml
-	$(AM_V_GEN)python2 $(srcdir)/modules/mavlink/pymavlink/tools/mavgen.py \
+	$(AM_V_GEN)python3 $(srcdir)/modules/mavlink/pymavlink/tools/mavgen.py \
 		-o include/mavlink \
 		--lang C \
 		--wire-protocol 2.0 \

--- a/src/mavlink-router/autolog.h
+++ b/src/mavlink-router/autolog.h
@@ -43,6 +43,7 @@ protected:
     // These functions should never be called
     const char *_get_logfile_extension() override { return ""; };
     bool _start_timeout() override { return true; };
+    bool _stop_timeout() override { return true; };
 
 private:
     std::unique_ptr<LogEndpoint> _logger;

--- a/src/mavlink-router/binlog.cpp
+++ b/src/mavlink-router/binlog.cpp
@@ -39,6 +39,12 @@ bool BinLog::_start_timeout()
     return true;
 }
 
+bool BinLog::_stop_timeout()
+{
+    // TODO: Stop timeout not implemented for binlog, see example in ulog
+    _remove_stop_timeout();
+}
+
 bool BinLog::start()
 {
     if (!LogEndpoint::start()) {

--- a/src/mavlink-router/binlog.h
+++ b/src/mavlink-router/binlog.h
@@ -40,6 +40,7 @@ public:
 protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override { return 0; };
     bool _start_timeout() override;
+    bool _stop_timeout() override;
 
     const char *_get_logfile_extension() override { return "bin"; };
 private:

--- a/src/mavlink-router/logendpoint.cpp
+++ b/src/mavlink-router/logendpoint.cpp
@@ -135,6 +135,11 @@ int LogEndpoint::_get_file(const char *extension)
 
 void LogEndpoint::stop()
 {
+    if (_logging_stop_timeout) {
+        // a stop was already requested
+        return;
+    }
+
     Mainloop &mainloop = Mainloop::get_instance();
     if (_logging_start_timeout) {
         mainloop.del_timeout(_logging_start_timeout);
@@ -155,10 +160,22 @@ void LogEndpoint::stop()
     if (snprintf(log_file, sizeof(log_file), "%s/%s", _logs_dir, _filename) < (int)sizeof(log_file)) {
         chmod(log_file, S_IRUSR|S_IRGRP|S_IROTH);
     }
+
+    _logging_stop_timeout = Mainloop::get_instance().add_timeout(
+        MSEC_PER_SEC, std::bind(&LogEndpoint::_stop_timeout, this), this);
+    if (!_logging_stop_timeout) {
+        log_error("Unable to add timeout for stopping log streaming");
+    }
+
+    _stop_timeout();
 }
 
 bool LogEndpoint::start()
 {
+    if (_logging_stop_timeout) {
+        return false;
+    }
+
     if (_file != -1) {
         log_warning("Log already started");
         return false;
@@ -205,6 +222,12 @@ void LogEndpoint::_remove_start_timeout()
     _logging_start_timeout = nullptr;
 }
 
+void LogEndpoint::_remove_stop_timeout()
+{
+    Mainloop::get_instance().del_timeout(_logging_stop_timeout);
+    _logging_stop_timeout = nullptr;
+}
+
 bool LogEndpoint::_start_alive_timeout()
 {
     _alive_check_timeout = Mainloop::get_instance().add_timeout(
@@ -220,7 +243,7 @@ void LogEndpoint::_handle_auto_start_stop(uint32_t msg_id, uint8_t source_system
     }
     if (_mode == LogMode::always) {
         if (_file == -1) {
-            if (!start()) _mode = LogMode::disabled;
+            if (!start() && !_logging_stop_timeout) _mode = LogMode::disabled;
         }
     } else if (_mode == LogMode::while_armed) {
         if (msg_id == MAVLINK_MSG_ID_HEARTBEAT && source_system_id == _target_system_id
@@ -229,7 +252,7 @@ void LogEndpoint::_handle_auto_start_stop(uint32_t msg_id, uint8_t source_system
             const mavlink_heartbeat_t *heartbeat = (mavlink_heartbeat_t *)payload;
             const bool is_armed = heartbeat->system_status == MAV_STATE_ACTIVE;
 
-            if (_file == -1 && is_armed) {
+            if (_file == -1 && is_armed && !_logging_stop_timeout) {
                 if (!start()) _mode = LogMode::disabled;
             } else if (_file != -1 && !is_armed) {
                 stop();

--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -48,6 +48,8 @@ public:
     virtual bool start();
     virtual void stop();
 
+    bool has_active_stop_timeout() {return _logging_stop_timeout != nullptr;}
+
 protected:
     const char *_logs_dir;
     int _target_system_id = -1;
@@ -55,6 +57,7 @@ protected:
     LogMode _mode;
 
     Timeout *_logging_start_timeout = nullptr;
+    Timeout *_logging_stop_timeout = nullptr;
     Timeout *_alive_check_timeout = nullptr;
     uint32_t _timeout_write_total = 0;
 
@@ -62,9 +65,11 @@ protected:
 
     void _send_msg(const mavlink_message_t *msg, int target_sysid);
     void _remove_start_timeout();
+    void _remove_stop_timeout();
     bool _start_alive_timeout();
 
     virtual bool _start_timeout() = 0;
+    virtual bool _stop_timeout() = 0;
     virtual bool _alive_timeout();
 
     void _handle_auto_start_stop(uint32_t msg_id, uint8_t source_system_id,

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -30,6 +30,9 @@
 
 #include "autolog.h"
 
+#define TIMEOUT_LOG_SHUTDOWN_US     5000000ULL // number of microseconds we wait until we give up trying to stop log streaming
+                                        // after a shutdown of mavlink router was requested
+
 static volatile bool should_exit = false;
 
 Mainloop Mainloop::_instance{};
@@ -261,7 +264,11 @@ void Mainloop::loop()
     add_timeout(LOG_AGGREGATE_INTERVAL_SEC * MSEC_PER_SEC,
                 std::bind(&Mainloop::_log_aggregate_timeout, this, std::placeholders::_1), this);
 
-    while (!should_exit) {
+    usec_t timestamp_stop_requested = 0;
+
+    bool run_loop= true;
+
+    while (run_loop) {
         int i;
 
         r = epoll_wait(epollfd, events, max_events, -1);
@@ -294,6 +301,22 @@ void Mainloop::loop()
                 // make poll errors fatal so that an external component can
                 // restart mavlink-router
                 should_exit = true;
+            }
+
+            // we should exit the router, make sure to stop the logendpoint properly (e.g. wait for ACK)
+            // we will try for max TIMEOUT_LOG_SHUTDOWN_US to shut down the log stream before we give up and exit anyways
+            if (should_exit) {
+                if (!_log_endpoint) {
+                    // no log streaming active, exit
+                    run_loop = false;
+                } else if (_log_endpoint && timestamp_stop_requested == 0) {
+                    // log streaming is active, start timing
+                    timestamp_stop_requested = now_usec();
+                    _log_endpoint->stop();
+                } else if (_log_endpoint && (!_log_endpoint->has_active_stop_timeout() || (now_usec() - timestamp_stop_requested) > TIMEOUT_LOG_SHUTDOWN_US)) {
+                    // log stream was either shut down successfully or we ran into timeout, exit
+                    run_loop = false;
+                }
             }
         }
 

--- a/src/mavlink-router/ulog.h
+++ b/src/mavlink-router/ulog.h
@@ -37,6 +37,7 @@ public:
 protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override { return 0; };
     bool _start_timeout() override;
+    bool _stop_timeout() override;
 
     const char *_get_logfile_extension() override { return "ulg"; };
 private:


### PR DESCRIPTION
@bkueng I added logic to continuously request the ulog stream to be stopped until an ack is received from the flight controller.
I did a lot of robustness testing and this seems to work fine. Can you have a look?
What's missing is the implementation for the other log types.
Signed-off-by: Roman <bapstroman@gmail.com>