### PR TITLE
Message filtering

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -327,10 +327,17 @@ bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid
         return false;
 
     if (msg_id != UINT32_MAX && 
-        _message_filter.size() > 0 && 
-        std::find(_message_filter.begin(), _message_filter.end(), msg_id) == _message_filter.end()) {
+        _message_filter_inclusive.size() > 0 && 
+        std::find(_message_filter_inclusive.begin(), _message_filter_inclusive.end(), msg_id) == _message_filter_inclusive.end()) {
 
-        // if filter is defined and message is not in the set then discard it
+        // if inclusive filter is defined and message is not in the set then discard it
+        return false;
+    }
+    if (msg_id != UINT32_MAX && 
+        _message_filter_exclusive.size() > 0 && 
+        std::find(_message_filter_exclusive.begin(), _message_filter_exclusive.end(), msg_id) != _message_filter_exclusive.end()) {
+
+        // if exclusive filter is defined and message is in the set then discard it
         return false;
     }
 

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -98,7 +98,9 @@ public:
 
     bool accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid, uint32_t msg_id);
 
-    void add_message_to_filter(uint32_t msg_id) { _message_filter.push_back(msg_id); }
+    void add_message_to_inclusive_filter(uint32_t msg_id) { _message_filter_inclusive.push_back(msg_id); }
+
+    void add_message_to_exclusive_filter(uint32_t msg_id) { _message_filter_exclusive.push_back(msg_id); }
 
     void start_expire_timer();
 
@@ -141,7 +143,8 @@ protected:
 
 private:
     Timeout* _expire_timer = nullptr;
-    std::vector<uint32_t> _message_filter;
+    std::vector<uint32_t> _message_filter_inclusive;
+    std::vector<uint32_t> _message_filter_exclusive;
 };
 
 class UartEndpoint : public Endpoint {

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -509,11 +509,18 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
                 return false;
             }
 
-            if (conf->filter) {
-                char *token = strtok(conf->filter, ",");
-                while (token != nullptr) {
-                    udp->add_message_to_filter(atoi(token));
-                    token = strtok(nullptr, ",");
+            if (conf->filter_inc) {
+                char *token = strtok(conf->filter_inc, ",");
+                while (token != NULL) {
+                    udp->add_message_to_inclusive_filter(atoi(token));
+                    token = strtok(NULL, ",");
+                } 
+            }
+            if (conf->filter_exc) {
+                char *token = strtok(conf->filter_exc, ",");
+                while (token != NULL) {
+                    udp->add_message_to_exclusive_filter(atoi(token));
+                    token = strtok(NULL, ",");
                 } 
             }
 

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -497,6 +497,21 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
                     return false;
             }
 
+            if (conf->tx_filter_inc) {
+                char *token = strtok(conf->tx_filter_inc, ",");
+                while (token != NULL) {
+                    uart->add_message_to_inclusive_filter(atoi(token));
+                    token = strtok(NULL, ",");
+                } 
+            }
+            if (conf->tx_filter_exc) {
+                char *token = strtok(conf->tx_filter_exc, ",");
+                while (token != NULL) {
+                    uart->add_message_to_exclusive_filter(atoi(token));
+                    token = strtok(NULL, ",");
+                } 
+            }
+
             g_endpoints[i] = uart.release();
             mainloop.add_fd(g_endpoints[i]->fd, g_endpoints[i], EPOLLIN);
             i++;
@@ -509,15 +524,15 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
                 return false;
             }
 
-            if (conf->filter_inc) {
-                char *token = strtok(conf->filter_inc, ",");
+            if (conf->tx_filter_inc) {
+                char *token = strtok(conf->tx_filter_inc, ",");
                 while (token != NULL) {
                     udp->add_message_to_inclusive_filter(atoi(token));
                     token = strtok(NULL, ",");
                 } 
             }
-            if (conf->filter_exc) {
-                char *token = strtok(conf->filter_exc, ",");
+            if (conf->tx_filter_exc) {
+                char *token = strtok(conf->tx_filter_exc, ",");
                 while (token != NULL) {
                     udp->add_message_to_exclusive_filter(atoi(token));
                     token = strtok(NULL, ",");
@@ -538,6 +553,21 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
                     _add_tcp_retry(tcp.release());
                 }
                 continue;
+            }
+
+            if (conf->tx_filter_inc) {
+                char *token = strtok(conf->tx_filter_inc, ",");
+                while (token != NULL) {
+                    tcp->add_message_to_inclusive_filter(atoi(token));
+                    token = strtok(NULL, ",");
+                } 
+            }
+            if (conf->tx_filter_exc) {
+                char *token = strtok(conf->tx_filter_exc, ",");
+                while (token != NULL) {
+                    tcp->add_message_to_exclusive_filter(atoi(token));
+                    token = strtok(NULL, ",");
+                } 
             }
 
             if (_add_tcp_endpoint(tcp.get()) < 0) {

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -129,8 +129,8 @@ struct endpoint_config {
             bool flowcontrol;
         };
     };
-    char *filter_inc;
-    char *filter_exc;
+    char *tx_filter_inc;
+    char *tx_filter_exc;
 };
 
 struct options {

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -129,7 +129,8 @@ struct endpoint_config {
             bool flowcontrol;
         };
     };
-    char *filter;
+    char *filter_inc;
+    char *filter_exc;
 };
 
 struct options {

--- a/src/mavlink-router/ulog.cpp
+++ b/src/mavlink-router/ulog.cpp
@@ -201,7 +201,7 @@ int ULog::write_msg(const struct buffer *buffer)
         mavlink_msg_logging_ack_encode(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg, &ack);
         _send_msg(&msg, _target_system_id);
         /* message will be handled by MAVLINK_MSG_ID_LOGGING_DATA case */
-        /* fall through */
+        [[gnu::fallthrough]];
     }
     case MAVLINK_MSG_ID_LOGGING_DATA: {
         if (trimmed_zeros) {


### PR DESCRIPTION
Add Filter field to endpoint configuration to limit the messages that are sent to particular endpoint and improve performance.
For example XYZ is interested only in messages 24,33,76,320,321,323.
This configuration filters all other messages so that they're not sent to XYZ and don't need to be parsed.

[UdpEndpoint XYZ]
Mode = Normal
Address = 127.0.0.1
Port = 14530
Filter = 24,33,76,320,321,323