### PR TITLE
Pr cleanup

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -72,7 +72,7 @@ int Endpoint::handle_read()
     uint8_t src_sysid, src_compid;
     struct buffer buf{};
 
-    while ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid)) > 0)
+    if ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid)) > 0)
         Mainloop::get_instance().route_msg(&buf, target_sysid, target_compid, src_sysid,
                                            src_compid);
 

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -212,10 +212,11 @@ static int add_endpoint_address(const char *name, size_t name_len, const char *i
     struct endpoint_config *conf
         = (struct endpoint_config *)calloc(1, sizeof(struct endpoint_config));
     assert_or_return(conf, -ENOMEM);
+    assert_or_return(ip != nullptr, -EINVAL);
     conf->type = Udp;
     conf->port = ULONG_MAX;
 
-    if (!conf->name && name) {
+    if (name) {
         conf->name = strndup(name, name_len);
         if (!conf->name) {
             ret = -ENOMEM;
@@ -223,17 +224,9 @@ static int add_endpoint_address(const char *name, size_t name_len, const char *i
         }
     }
 
-    if (ip) {
-        free(conf->address);
-        conf->address = strdup(ip);
-        if (!conf->address) {
-            ret = -ENOMEM;
-            goto fail;
-        }
-    }
-
+    conf->address = strdup(ip);
     if (!conf->address) {
-        ret = -EINVAL;
+        ret = -ENOMEM;
         goto fail;
     }
 

--- a/src/mavlink-router/ulog.cpp
+++ b/src/mavlink-router/ulog.cpp
@@ -191,7 +191,7 @@ int ULog::write_msg(const struct buffer *buffer)
         mavlink_msg_logging_ack_encode(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg, &ack);
         _send_msg(&msg, _target_system_id);
         /* message will be handled by MAVLINK_MSG_ID_LOGGING_DATA case */
-        [[gnu::fallthrough]];
+        /* fall through */
     }
     case MAVLINK_MSG_ID_LOGGING_DATA: {
         if (trimmed_zeros) {


### PR DESCRIPTION
This PR contains 3 small improvements or code cleanups:

    Fall through compile warning: attribute ((fallthrough)) was introduced in GCC 7. To maintain backward compatibility and clear the fall through warning for both Clang and GCC, you can use the /* fall through */
    main.cpp - since conf is calloc-ed at the beginning it contains only zeroes, so we don't have to check if it is null or even free null pointer.
    while/if read_msg - if first read doesn't read all the available data in the buffers then epoll raises event again, so the control will return to this code until everything is read. If we use while then reading of all file descriptors will be blocked until everything is read which might theoretically be indefinite.
