### PR TITLE
logendpoint: mark unfinished logs as read-only on startup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ matrix:
           packages:
             - g++-6
             - gcc-6
-            - python-pip
+            - python3-pip
 
 before_script:
-        - pip install --user future pymavlink
+        - pip3 install --user future pymavlink
         - CXX="g++-6"
         - CC="gcc-6"
 
 script:
         - ./autogen.sh c --with-systemdsystemunitdir=/usr/lib/systemd/system
         - make -j
-        - make check
+        - make check PYTHON=python3

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ clean-local:
 	rm -f $(top_builddir)/tests/unit_test
 
 include/mavlink/ardupilotmega/mavlink.h: modules/mavlink/pymavlink/tools/mavgen.py modules/mavlink/message_definitions/v1.0/ardupilotmega.xml
-	$(AM_V_GEN)python2 $(srcdir)/modules/mavlink/pymavlink/tools/mavgen.py \
+	$(AM_V_GEN)python3 $(srcdir)/modules/mavlink/pymavlink/tools/mavgen.py \
 		-o include/mavlink \
 		--lang C \
 		--wire-protocol 2.0 \

--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -48,6 +48,13 @@ public:
     virtual bool start();
     virtual void stop();
 
+    /**
+     * Check existing log files and mark logs as read-only if needed.
+     * This handles the case where the system (or mavlink-router) crashed or
+     * lost power.
+     */
+    void mark_unfinished_logs();
+
 protected:
     const char *_logs_dir;
     int _target_system_id = -1;

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -441,6 +441,7 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
         } else {
             _log_endpoint = new AutoLog(opt->logs_dir, opt->log_mode);
         }
+        _log_endpoint->mark_unfinished_logs();
         g_endpoints[i] = _log_endpoint;
     }
 


### PR DESCRIPTION
If the system or mavlink-router crashed, the last log was not marked as
read-only, so we go through all logs on startup and check them.