### PR TITLE
Pr fix pb latency

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -82,7 +82,7 @@ AM_CFLAGS = \
 	-fdiagnostics-show-option \
 	-fvisibility=hidden \
 	-ffunction-sections \
-	-fdata-sections
+	-fdata-sections 
 
 AM_CXXFLAGS = \
 	-pipe \
@@ -148,6 +148,7 @@ mavlink_routerd_SOURCES = \
 	src/mavlink-router/mainloop.h \
 	src/mavlink-router/pollable.h \
 	src/mavlink-router/pollable.cpp \
+	src/mavlink-router/priority-ack.cpp \
 	src/mavlink-router/timeout.h \
 	src/mavlink-router/timeout.cpp \
 	src/mavlink-router/ulog.h \

--- a/src/mavlink-router/priority-ack.cpp
+++ b/src/mavlink-router/priority-ack.cpp
@@ -1,0 +1,60 @@
+#include <functional>
+#include <unistd.h>
+#include <mutex>
+
+#include <sys/types.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+
+#include <mavlink.h>
+
+#include "mainloop.h"
+#include "priority-ack.h"
+
+PriorityAck::PriorityAck() {
+    _initial_nice_val = getpriority(PRIO_PROCESS, getpid());
+    _timer_running = false;
+    _this_pid = getpid();
+}
+
+bool PriorityAck::_reset_nice_value() {
+
+    if ((getpriority(PRIO_PROCESS, _this_pid) != _initial_nice_val)) {
+        setpriority(PRIO_PROCESS, _this_pid, _initial_nice_val);
+    }
+
+    _timer_running = false;
+
+    return false;
+}
+
+void PriorityAck::_set_priority(uint32_t msg_id) {
+
+    // temporarily set the nice level of this process to -20 to keep
+    // up with incoming data transmissions when receiving an acked
+    // sequence of commands
+
+    int cur_pri = getpriority(PRIO_PROCESS, _this_pid);
+
+    if (msg_id == MAVLINK_MSG_ID_LOGGING_DATA_ACKED) {
+
+        if (cur_pri > -20) {
+            _initial_nice_val = cur_pri;
+            setpriority(PRIO_PROCESS, _this_pid, -20);
+        }
+
+        if (_timer_running == false) {
+            _timer_running = true;
+
+            // add a 5 sec timeout for resetting the nice level
+            // in case it doesn't get reset automatically
+
+            _priority_timeout = Mainloop::get_instance().add_timeout(5000,
+                                                                     std::bind(&PriorityAck::_reset_nice_value, this),
+                                                                     this);
+        }
+
+    } else if (cur_pri != _initial_nice_val) {
+        setpriority(PRIO_PROCESS, _this_pid, _initial_nice_val);
+    }
+}

--- a/src/mavlink-router/priority-ack.h
+++ b/src/mavlink-router/priority-ack.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "timeout.h"
+
+class PriorityAck {
+
+public:
+    PriorityAck();
+    virtual ~PriorityAck() {};
+
+    void _set_priority(uint32_t msg_id);    // sets the priority level based on the incoming message type
+    bool _reset_nice_value();               // resets the priority level to the value when this class was instaniated
+
+
+    int _initial_nice_val;
+    bool _timer_running;
+    Timeout * _priority_timeout = nullptr;
+    pid_t _this_pid;
+};
+

--- a/src/mavlink-router/ulog.cpp
+++ b/src/mavlink-router/ulog.cpp
@@ -146,6 +146,10 @@ int ULog::write_msg(const struct buffer *buffer)
         return buffer->len;
     }
 
+    // set priority for low latency ack connections
+
+    _priority_ack._set_priority(msg_id);
+
     const mavlink_msg_entry_t *msg_entry = mavlink_get_msg_entry(msg_id);
     if (!msg_entry) {
         return buffer->len;
@@ -338,6 +342,13 @@ void ULog::_logging_data_process(mavlink_logging_data_t *msg)
 
 bool ULog::_logging_flush()
 {
+
+    /* dont bother flushing if the fd is bad */
+
+    if(_file < 0) {
+        return false;
+    }
+
     while (_buffer_partial_len) {
         const ssize_t r = write(_file, _buffer_partial, _buffer_partial_len);
         if (r == 0 || (r == -1 && errno == EAGAIN))

--- a/src/mavlink-router/ulog.h
+++ b/src/mavlink-router/ulog.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "logendpoint.h"
+#include "priority-ack.h"
 
 #define BUFFER_LEN 2048
 
@@ -55,4 +56,8 @@ private:
     bool _logging_seq(uint16_t seq, bool *drop);
     void _logging_data_process(mavlink_logging_data_t *msg);
     bool _logging_flush();
+
+    /* for pocket beagle ack latency */
+    PriorityAck _priority_ack;
+
 };


### PR DESCRIPTION
This greatly reduces the amount of log file we lose after arming a drone when streaming the log to a PocketBeagle.
I quickly tested this on Friday and with a spool up time of 2 seconds we pretty much have the log from beginning.
@catch-twenty-two @bkueng FYI