### PR TITLE
Delete old logs as storage space runs low

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,6 +8,7 @@ AllowShortBlocksOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 ColumnLimit: 100
 Cpp11BracedListStyle: true
+SpaceBeforeCpp11BracedList: false
 DerivePointerAlignment: false
 IndentCaseLabels: false
 Language: Cpp

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ tags
 /heartbeat-print
 
 test.log
+
+# Jetbrains IDEs
+.idea/
+compile_commands.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-dist: trusty
+dist: bionic
 cache: pip
 matrix:
   include:
@@ -12,6 +12,7 @@ matrix:
             - g++-6
             - gcc-6
             - python3-pip
+            - python3-setuptools
 
 before_script:
         - pip3 install --user future pymavlink

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ matrix:
           packages:
             - g++-6
             - gcc-6
-            - python-pip
+            - python3-pip
 
 before_script:
-        - pip install --user future pymavlink
+        - pip3 install --user future pymavlink
         - CXX="g++-6"
         - CC="gcc-6"
 
 script:
         - ./autogen.sh c --with-systemdsystemunitdir=/usr/lib/systemd/system
         - make -j
-        - make check
+        - make check PYTHON=python3

--- a/Makefile.am
+++ b/Makefile.am
@@ -136,6 +136,7 @@ mavlink_routerd_SOURCES = \
 	src/common/conf_file.cpp \
 	src/common/conf_file.h \
 	src/common/dbg.h \
+	src/common/mavlink.h \
 	src/mavlink-router/endpoint.cpp \
 	src/mavlink-router/endpoint.h \
 	src/common/log.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -124,7 +124,8 @@ AM_CXXFLAGS = \
 AM_LDFLAGS = \
 	-Wl,--as-needed \
 	-Wl,--no-undefined \
-	-Wl,--gc-sections
+	-Wl,--gc-sections \
+	-lrt
 
 bin_PROGRAMS += mavlink-routerd
 mavlink_routerd_SOURCES = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ clean-local:
 	rm -f $(top_builddir)/tests/unit_test
 
 include/mavlink/ardupilotmega/mavlink.h: modules/mavlink/pymavlink/tools/mavgen.py modules/mavlink/message_definitions/v1.0/ardupilotmega.xml
-	$(AM_V_GEN)python2 $(srcdir)/modules/mavlink/pymavlink/tools/mavgen.py \
+	$(AM_V_GEN)python3 $(srcdir)/modules/mavlink/pymavlink/tools/mavgen.py \
 		-o include/mavlink \
 		--lang C \
 		--wire-protocol 2.0 \

--- a/examples/arm-authorizer.cpp
+++ b/examples/arm-authorizer.cpp
@@ -27,7 +27,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#include <mavlink.h>
+#include <common/mavlink.h>
 
 #define SYSTEM_ID 10
 

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -37,6 +37,16 @@
 #       If set to while-armed, a new log file is created whenever the vehicle is
 #       armed, and closed when disarmed.
 #
+#   MinFreeSpace
+#       The Log Endpoint will delete old log files until there are MinFreeSpace bytes
+#       available on the storage device of the logs. Set to 0 to ignore this limit.
+#       Default: 0 (disabled)
+#
+#   MaxLogFiles
+#       Maximum number of log files to keep. The Log Endpoint will delete old
+#       log files to keep the total below this number. Set to 0 to ignore this limit.
+#       Default: 0 (disabled)
+#
 #   DebugLogLevel
 #       One of <error>, <warning>, <info> or <debug>. Which debug log
 #       level is being used by mavlink-router, with <debug> being the

--- a/examples/heartbeat-print.cpp
+++ b/examples/heartbeat-print.cpp
@@ -26,7 +26,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include <mavlink.h>
+#include <common/mavlink.h>
 
 static volatile bool g_should_exit;
 

--- a/examples/px4-offboard-mode.cpp
+++ b/examples/px4-offboard-mode.cpp
@@ -48,7 +48,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#include <mavlink.h>
+#include <common/mavlink.h>
 
 #include "common/util.h"
 

--- a/src/common/mavlink.h
+++ b/src/common/mavlink.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#pragma GCC diagnostic push
+/*
+ * All structs in mavlink are packed since they are "on-the-wire" definition,
+ * but then pymavlink generates helper functions that take the address of
+ * members of those structs - that's not good, but there's nothing we can do,
+ * so shut up the warnings.
+ *
+ * Unaligned access is generally slower, but should work in most of today
+ * platforms, so this is not harmful. Also, pymavlink supposedly uses just
+ * memcpy() to access the fields so, but if you have a variant of sparc,
+ * mips, arm, etc that doesn't silently handle unaligned access,
+ * you may be interested checking case by case in mavlink/pymavlink.
+ */
+#if defined(__GNUC__) && __GNUC__ >= 9
+#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+#endif
+#include <mavlink.h>
+#pragma GCC diagnostic pop
+

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -56,3 +56,14 @@ int mkdir_p(const char *path, int len, mode_t mode);
 #ifdef __cplusplus
 }
 #endif
+
+#ifndef strndupa
+#define strndupa(s, n) \
+       (__extension__ ({const char *__in = (s); \
+                        size_t __len = strnlen (__in, (n)); \
+                        char *__out = (char *) alloca (__len + 1); \
+                        __out[__len] = '\0'; \
+                        (char *) memcpy (__out, __in, __len);}))
+
+#include <asm/ioctls.h>
+#endif

--- a/src/mavlink-router/autolog.cpp
+++ b/src/mavlink-router/autolog.cpp
@@ -65,9 +65,11 @@ int AutoLog::write_msg(const struct buffer *buffer)
     /* We check autopilot on heartbeat */
     log_debug("Got autopilot %u from heartbeat", heartbeat->autopilot);
     if (heartbeat->autopilot == MAV_AUTOPILOT_PX4) {
-        _logger = std::unique_ptr<LogEndpoint>(new ULog(_logs_dir, _mode));
+        _logger
+            = std::unique_ptr<LogEndpoint>(new ULog(_logs_dir, _mode, _min_free_space, _max_files));
     } else if (heartbeat->autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA) {
-        _logger = std::unique_ptr<LogEndpoint>(new BinLog(_logs_dir, _mode));
+        _logger = std::unique_ptr<LogEndpoint>(
+            new BinLog(_logs_dir, _mode, _min_free_space, _max_files));
     } else {
         log_warning("Unidentified autopilot, cannot start flight stack logging");
     }

--- a/src/mavlink-router/autolog.h
+++ b/src/mavlink-router/autolog.h
@@ -24,9 +24,9 @@
 
 class AutoLog : public LogEndpoint {
 public:
-
-    AutoLog(const char *logs_dir, LogMode mode)
-        : LogEndpoint{"AutoLog", logs_dir, mode}
+    AutoLog(const char *logs_dir, LogMode mode, unsigned long min_free_space,
+            unsigned long max_files)
+        : LogEndpoint{"AutoLog", logs_dir, mode, min_free_space, max_files}
     {
     }
 

--- a/src/mavlink-router/binlog.h
+++ b/src/mavlink-router/binlog.h
@@ -24,8 +24,9 @@
 
 class BinLog : public LogEndpoint {
 public:
-    BinLog(const char *logs_dir, LogMode mode)
-        : LogEndpoint{"BinLog", logs_dir, mode}
+    BinLog(const char *logs_dir, LogMode mode, unsigned long min_free_space,
+           unsigned long max_files)
+        : LogEndpoint{"BinLog", logs_dir, mode, min_free_space, max_files}
     {
     }
 

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -18,6 +18,7 @@
 #include "endpoint.h"
 
 #include <arpa/inet.h>
+#include <algorithm>
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -72,20 +73,20 @@ int Endpoint::handle_read()
 {
     int target_sysid, target_compid, r;
     uint8_t src_sysid, src_compid;
+    uint32_t msg_id;
     struct buffer buf{};
 
-    while ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid)) > 0)
+    while ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid, &src_compid, &msg_id)) > 0)
         Mainloop::get_instance().route_msg(&buf, target_sysid, target_compid, src_sysid,
-                                           src_compid);
+                                           src_compid, msg_id);
 
     return r;
 }
 
 int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compid,
-                       uint8_t *src_sysid, uint8_t *src_compid)
+                       uint8_t *src_sysid, uint8_t *src_compid, uint32_t *msg_id)
 {
     bool should_read_more = true;
-    uint32_t msg_id;
     const mavlink_msg_entry_t *msg_entry;
     uint8_t *payload, seq, payload_len;
 
@@ -173,7 +174,7 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
         if (rx_buf.len < sizeof(*hdr))
             return 0;
 
-        msg_id = hdr->msgid;
+        *msg_id = hdr->msgid;
         payload = rx_buf.data + sizeof(*hdr);
         seq = hdr->seq;
         *src_sysid = hdr->sysid;
@@ -192,7 +193,7 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
         if (rx_buf.len < sizeof(*hdr))
             return 0;
 
-        msg_id = hdr->msgid;
+        *msg_id = hdr->msgid;
         payload = rx_buf.data + sizeof(*hdr);
         seq = hdr->seq;
         *src_sysid = hdr->sysid;
@@ -214,7 +215,7 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
     _last_packet_len = expected_size;
     _stat.read.total++;
 
-    msg_entry = mavlink_get_msg_entry(msg_id);
+    msg_entry = mavlink_get_msg_entry(*msg_id);
     if (_crc_check_enabled && msg_entry) {
         /*
          * It is accepting and forwarding unknown messages ids because
@@ -240,7 +241,7 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
     *target_compid = -1;
 
     if (msg_entry == nullptr) {
-        log_debug("No message entry for %u", msg_id);
+        log_debug("No message entry for %u", *msg_id);
     } else {
         if (msg_entry->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_SYSTEM) {
             // if target_system is 0, it may have been trimmed out on mavlink2
@@ -258,6 +259,7 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
                 *target_compid = 0;
             }
         }
+        *msg_id = msg_entry->msgid;
     }
 
     // Check for sequence drops
@@ -311,7 +313,7 @@ bool Endpoint::has_sys_comp_id(unsigned sys_comp_id)
 }
 
 bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid,
-                          uint8_t src_compid)
+                          uint8_t src_compid, uint32_t msg_id)
 {
     if (Log::get_max_level() >= Log::Level::DEBUG) {
         log_debug("Endpoint [%d] got message to %d/%d from %u/%u", fd, target_sysid, target_compid,
@@ -326,6 +328,14 @@ bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid
     // same channel to avoid loops: reject
     if (has_sys_comp_id(src_sysid, src_compid))
         return false;
+
+    if (msg_id != UINT32_MAX && 
+        _message_filter.size() > 0 && 
+        std::find(_message_filter.begin(), _message_filter.end(), msg_id) == _message_filter.end()) {
+
+        // if filter is defined and message is not in the set then discard it
+        return false;
+    }
 
     // Message is broadcast on sysid: accept msg
     if (target_sysid == 0 || target_sysid == -1)
@@ -598,9 +608,9 @@ bool UartEndpoint::_change_baud_cb(void *data)
 }
 
 int UartEndpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compid,
-                           uint8_t *src_sysid, uint8_t *src_compid)
+                           uint8_t *src_sysid, uint8_t *src_compid, uint32_t *msg_id)
 {
-    int ret = Endpoint::read_msg(pbuf, target_sysid, target_compid, src_sysid, src_compid);
+    int ret = Endpoint::read_msg(pbuf, target_sysid, target_compid, src_sysid, src_compid, msg_id);
 
     if (_change_baud_timeout != nullptr && ret == ReadOk) {
         log_info("Baudrate %lu responded, keeping it", _baudrates[_current_baud_idx]);

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -17,7 +17,7 @@
  */
 #pragma once
 
-#include <mavlink.h>
+#include <common/mavlink.h>
 
 #include <memory>
 #include <vector>

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -75,7 +75,7 @@ public:
         ReadUnkownMsg,
     };
 
-    Endpoint(const char *name, bool crc_check_enabled);
+    Endpoint(const char *name);
     virtual ~Endpoint();
 
     int handle_read() override;
@@ -130,7 +130,6 @@ protected:
         } write;
     } _stat;
 
-    const bool _crc_check_enabled;
     uint32_t _incomplete_msgs = 0;
     std::vector<uint16_t> _sys_comp_ids;
 
@@ -140,7 +139,10 @@ private:
 
 class UartEndpoint : public Endpoint {
 public:
-    UartEndpoint() : Endpoint{"UART", true} { }
+    UartEndpoint()
+        : Endpoint {"UART"}
+    {
+    }
     virtual ~UartEndpoint();
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -96,14 +96,16 @@ public:
         return has_sys_comp_id(sys_comp_id);
     }
 
-    bool accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid);
+    bool accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid, uint32_t msg_id);
+
+    void add_message_to_filter(uint32_t msg_id) { _message_filter.push_back(msg_id); }
 
     struct buffer rx_buf;
     struct buffer tx_buf;
 
 protected:
     virtual int read_msg(struct buffer *pbuf, int *target_system, int *target_compid,
-                         uint8_t *src_sysid, uint8_t *src_compid);
+                         uint8_t *src_sysid, uint8_t *src_compid, uint32_t *msg_id);
     virtual ssize_t _read_msg(uint8_t *buf, size_t len) = 0;
     bool _check_crc(const mavlink_msg_entry_t *msg_entry);
     void _add_sys_comp_id(uint16_t sys_comp_id);
@@ -131,6 +133,9 @@ protected:
     const bool _crc_check_enabled;
     uint32_t _incomplete_msgs = 0;
     std::vector<uint16_t> _sys_comp_ids;
+
+private:
+    std::vector<uint32_t> _message_filter;
 };
 
 class UartEndpoint : public Endpoint {
@@ -147,7 +152,7 @@ public:
 
 protected:
     int read_msg(struct buffer *pbuf, int *target_system, int *target_compid, uint8_t *src_sysid,
-                 uint8_t *src_compid) override;
+                 uint8_t *src_compid, uint32_t *msg_id) override;
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 
 private:

--- a/src/mavlink-router/logendpoint.cpp
+++ b/src/mavlink-router/logendpoint.cpp
@@ -39,7 +39,7 @@
 #define MAX_RETRIES 10
 
 LogEndpoint::LogEndpoint(const char *name, const char *logs_dir, LogMode mode)
-    : Endpoint {name, false}
+    : Endpoint {name}
     , _logs_dir {logs_dir}
     , _mode(mode)
 {

--- a/src/mavlink-router/logendpoint.cpp
+++ b/src/mavlink-router/logendpoint.cpp
@@ -54,6 +54,39 @@ void LogEndpoint::_send_msg(const mavlink_message_t *msg, int target_sysid)
     _stat.read.handled_bytes += buffer.len;
 }
 
+void LogEndpoint::mark_unfinished_logs()
+{
+    DIR *dir = opendir(_logs_dir);
+
+    // Assume the directory does not exist if opendir failed
+    if (!dir) {
+        return;
+    }
+
+    struct dirent *ent;
+    uint32_t u;
+
+    while ((ent = readdir(dir)) != nullptr) {
+        if (sscanf(ent->d_name, "%u-", &u) != 1)
+            continue;
+
+        char log_file[PATH_MAX];
+        struct stat file_stat;
+        if (snprintf(log_file, sizeof(log_file), "%s/%s", _logs_dir, ent->d_name)
+            >= (int)sizeof(log_file))
+            continue;
+
+        if (stat(log_file, &file_stat))
+            continue;
+
+        if (S_ISREG(file_stat.st_mode) && (file_stat.st_mode & S_IWUSR)) {
+            log_info("File %s not read-only yet, marking as RO", ent->d_name);
+            chmod(log_file, S_IRUSR | S_IRGRP | S_IROTH);
+        }
+    }
+    closedir(dir);
+}
+
 uint32_t LogEndpoint::_get_prefix(DIR *dir)
 {
     struct dirent *ent;

--- a/src/mavlink-router/logendpoint.cpp
+++ b/src/mavlink-router/logendpoint.cpp
@@ -24,11 +24,16 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/statvfs.h>
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 
+#include <algorithm>
+#include <map>
 #include <memory>
+#include <tuple>
+#include <vector>
 
 #include <common/log.h>
 #include <common/util.h>
@@ -38,9 +43,12 @@
 #define ALIVE_TIMEOUT 5
 #define MAX_RETRIES 10
 
-LogEndpoint::LogEndpoint(const char *name, const char *logs_dir, LogMode mode)
-    : Endpoint {name}
-    , _logs_dir {logs_dir}
+LogEndpoint::LogEndpoint(const char *name, const char *logs_dir, LogMode mode,
+                         unsigned long min_free_space, unsigned long max_files)
+    : Endpoint{name}
+    , _logs_dir{logs_dir}
+    , _min_free_space(min_free_space)
+    , _max_files(max_files)
     , _mode(mode)
 {
     assert(_logs_dir);
@@ -100,6 +108,110 @@ void LogEndpoint::mark_unfinished_logs()
             chmod(log_file, S_IRUSR | S_IRGRP | S_IROTH);
         }
     }
+    closedir(dir);
+}
+
+void LogEndpoint::_delete_old_logs()
+{
+
+    struct statvfs buf;
+    uint64_t free_space;
+    if (statvfs(_logs_dir, &buf) == 0) {
+        free_space = (uint64_t) buf.f_bsize * buf.f_bavail;
+    } else {
+        free_space = UINT64_MAX;
+        log_error("[Log Deletion] Error when measuring free disk space: %m");
+    }
+    log_debug("[Log Deletion]  Total free space: %lumb. Min free space: %lumb",
+              free_space / (1ul << 20), _min_free_space / (1ul << 20));
+
+    // This check is not necessary, it just saves on some file IO.
+    if (free_space > _min_free_space && _max_files == 0) {
+        return;
+    }
+
+    DIR *dir = opendir(_logs_dir);
+
+    // Assume the directory does not exist if opendir failed
+    if (!dir) {
+        return;
+    }
+
+    int dir_fd = dirfd(dir);
+    if (dir_fd < 0) {
+        closedir(dir);
+        log_error("[Log Deletion] Error getting dir file descriptor: %m");
+        return;
+    }
+
+    // Map of index -> (filename, file size)
+    // All three of these values are saved for later to reduce the amount of IO operations needed.
+    std::map<unsigned long, std::tuple<std::string, unsigned long>> file_map;
+
+    struct dirent *ent;
+    uint32_t idx, year, month, day, hour, minute, second;
+
+    // This loop just gathers the name, index, and size of each read-only file in the log dir
+    while ((ent = readdir(dir)) != nullptr) {
+        // Even though we don't need the timestamp, we want to match as much of the filename as
+        // possible, so we don't accidentally delete something that isn't a log.
+        if (sscanf(ent->d_name, "%u-%u-%u-%u_%u-%u-%u.", &idx, &year, &month, &day, &hour, &minute,
+                   &second)
+            == 7) {
+            struct stat file_stat;
+            if (!fstatat(dir_fd, ent->d_name, &file_stat, 0)) {
+                // Only bother with read-only files. If this function is somehow called while a file
+                // is still being used (not read-only), it should not be deleted.
+                if (!S_ISDIR(file_stat.st_mode) && !(file_stat.st_mode & S_IWUSR)) {
+                    std::string str(ent->d_name);
+                    file_map[idx] = std::make_tuple(str, file_stat.st_size);
+                }
+            }
+        }
+    }
+
+    // If the configured value for _min_free_space is 0, then we don't have to do anything special.
+    uint64_t bytes_to_delete = _min_free_space - free_space;
+    // If the configured value for _max_files is 0, then set this to -1 to indicate that we've
+    // already deleted enough files.
+    uint64_t files_to_delete = _max_files > 0 ? file_map.size() - _max_files : -1;
+
+    log_debug("[Log Deletion] Files to delete: %ld", files_to_delete);
+
+    // Delete the logs in order until there's enough free space, and few enough files
+    // It is possible for this loop to run only once and return immediately, if we don't actually
+    // need to delete any files. Maps in C++ are ordered by the keys, so this iteration is
+    // guaranteed to happen in index order (oldest -> newest)
+    for (auto &pair : file_map) {
+        if (bytes_to_delete <= 0 && files_to_delete <= 0) {
+            break;
+        }
+
+        std::string &filename = std::get<0>(pair.second);
+        const unsigned long filesize = std::get<1>(pair.second);
+        char log_file[PATH_MAX];
+        if (snprintf(log_file, sizeof(log_file), "%s/%s", _logs_dir, filename.c_str())
+            >= (int)sizeof(log_file)) {
+            log_error("Directory + filename %s is longer than PATH_MAX of %d", filename.c_str(),
+                      PATH_MAX);
+            continue;
+        }
+
+        int err_code = remove(log_file);
+        if (err_code == 0) {
+            bytes_to_delete -= filesize;
+            files_to_delete--;
+            log_info("[Log Deletion] Deleted old logfile %s", filename.c_str());
+        } else {
+            log_error("[Log Deletion] Error deleting old logfile %s: %m", filename.c_str());
+        }
+    }
+
+    if (bytes_to_delete > 0) {
+        log_error(
+            "[Log Deletion] Deleted all closed logs, but there is still not enough free space.");
+    }
+
     closedir(dir);
 }
 
@@ -224,6 +336,9 @@ bool LogEndpoint::start()
         log_warning("Log already started");
         return false;
     }
+
+    // Clear up space before opening a new file
+    _delete_old_logs();
 
     _file = _get_file(_get_logfile_extension());
     if (_file < 0) {

--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -37,7 +37,8 @@ enum class LogMode {
 
 class LogEndpoint : public Endpoint {
 public:
-    LogEndpoint(const char *name, const char *logs_dir, LogMode mode);
+    LogEndpoint(const char *name, const char *logs_dir, LogMode mode, unsigned long min_free_space,
+                unsigned long max_files);
 
     virtual bool start();
     virtual void stop();
@@ -53,6 +54,8 @@ protected:
     const char *_logs_dir;
     int _target_system_id = -1;
     int _file = -1;
+    unsigned long _min_free_space;
+    unsigned long _max_files;
     LogMode _mode;
 
     Timeout *_logging_start_timeout = nullptr;
@@ -79,6 +82,12 @@ private:
     int _get_file(const char *extension);
     uint32_t _get_prefix(DIR *dir);
     DIR *_open_or_create_dir(const char *name);
+
+    /**
+     * Delete old logs until a certain amount of free space and total number of log files are met.
+     * This can be configured using the .conf file, options MinFreeSpace and MaxLogFiles.
+     */
+    void _delete_old_logs();
 
     char _filename[64];
 };

--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -48,6 +48,13 @@ public:
     virtual bool start();
     virtual void stop();
 
+    /**
+     * Check existing log files and mark logs as read-only if needed.
+     * This handles the case where the system (or mavlink-router) crashed or
+     * lost power.
+     */
+    void mark_unfinished_logs();
+
 protected:
     const char *_logs_dir;
     int _target_system_id = -1;

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -40,15 +40,17 @@
 #define DEFAULT_RETRY_TCP_TIMEOUT 5
 
 static struct options opt = {
-        .endpoints = nullptr,
-        .conf_file_name = nullptr,
-        .conf_dir = nullptr,
-        .tcp_port = ULONG_MAX,
-        .report_msg_statistics = false,
-        .logs_dir = nullptr,
-        .log_mode = LogMode::always,
-        .debug_log_level = (int)Log::Level::INFO,
-        .mavlink_dialect = Auto
+    .endpoints = nullptr,
+    .conf_file_name = nullptr,
+    .conf_dir = nullptr,
+    .tcp_port = ULONG_MAX,
+    .report_msg_statistics = false,
+    .logs_dir = nullptr,
+    .log_mode = LogMode::always,
+    .debug_log_level = (int)Log::Level::INFO,
+    .mavlink_dialect = Auto,
+    .min_free_space = 0,
+    .max_log_files = 0,
 };
 
 static const struct option long_options[] = {
@@ -652,12 +654,19 @@ static int parse_confs(ConfFile &conf)
     const char *pattern;
 
     static const ConfFile::OptionsTable option_table[] = {
-        {"TcpServerPort",   false, ConfFile::parse_ul,      OPTIONS_TABLE_STRUCT_FIELD(options, tcp_port)},
-        {"ReportStats",     false, ConfFile::parse_bool,    OPTIONS_TABLE_STRUCT_FIELD(options, report_msg_statistics)},
-        {"MavlinkDialect",  false, parse_mavlink_dialect,   OPTIONS_TABLE_STRUCT_FIELD(options, mavlink_dialect)},
-        {"Log",             false, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(options, logs_dir)},
-        {"LogMode",         false, parse_log_mode,          OPTIONS_TABLE_STRUCT_FIELD(options, log_mode)},
-        {"DebugLogLevel",   false, parse_log_level,         OPTIONS_TABLE_STRUCT_FIELD(options, debug_log_level)},
+        {"TcpServerPort", false, ConfFile::parse_ul, OPTIONS_TABLE_STRUCT_FIELD(options, tcp_port)},
+        {"ReportStats", false, ConfFile::parse_bool,
+         OPTIONS_TABLE_STRUCT_FIELD(options, report_msg_statistics)},
+        {"MavlinkDialect", false, parse_mavlink_dialect,
+         OPTIONS_TABLE_STRUCT_FIELD(options, mavlink_dialect)},
+        {"Log", false, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(options, logs_dir)},
+        {"LogMode", false, parse_log_mode, OPTIONS_TABLE_STRUCT_FIELD(options, log_mode)},
+        {"DebugLogLevel", false, parse_log_level,
+         OPTIONS_TABLE_STRUCT_FIELD(options, debug_log_level)},
+        {"MinFreeSpace", false, ConfFile::parse_ul,
+         OPTIONS_TABLE_STRUCT_FIELD(options, min_free_space)},
+        {"MaxLogFiles", false, ConfFile::parse_ul,
+         OPTIONS_TABLE_STRUCT_FIELD(options, max_log_files)},
     };
 
     struct option_uart {

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -205,7 +205,7 @@ fail:
 }
 
 static int add_endpoint_address(const char *name, size_t name_len, const char *ip,
-                                long unsigned port, bool eavesdropping)
+                                long unsigned port, bool eavesdropping, const char *filter)
 {
     int ret;
 
@@ -235,6 +235,14 @@ static int add_endpoint_address(const char *name, size_t name_len, const char *i
     if (!conf->address) {
         ret = -EINVAL;
         goto fail;
+    }
+    
+    if (filter) {
+        conf->filter = strdup(filter);
+        if (!conf->filter) {
+            ret = -ENOMEM;
+            goto fail;
+        }
     }
 
     if (port != ULONG_MAX) {
@@ -402,7 +410,7 @@ static int parse_argv(int argc, char *argv[])
                 return -EINVAL;
             }
 
-            add_endpoint_address(NULL, 0, ip, port, false);
+            add_endpoint_address(NULL, 0, ip, port, false, NULL);
             free(ip);
             break;
         }
@@ -488,7 +496,7 @@ static int parse_argv(int argc, char *argv[])
                 return -EINVAL;
             }
 
-            add_endpoint_address(NULL, 0, base, number, true);
+            add_endpoint_address(NULL, 0, base, number, true, NULL);
         } else {
             const char *bauds = number != ULONG_MAX ? base + strlen(base) + 1 : NULL;
             int ret = add_uart_endpoint(NULL, 0, base, bauds, false);
@@ -667,11 +675,13 @@ static int parse_confs(ConfFile &conf)
         char *addr;
         bool eavesdropping;
         unsigned long port;
+        char *filter;
     };
     static const ConfFile::OptionsTable option_table_udp[] = {
         {"address", true,   ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_udp, addr)},
         {"mode",    true,   parse_mode,                 OPTIONS_TABLE_STRUCT_FIELD(option_udp, eavesdropping)},
         {"port",    false,  ConfFile::parse_ul,         OPTIONS_TABLE_STRUCT_FIELD(option_udp, port)},
+        {"filter",  false,  ConfFile::parse_str_dup,    OPTIONS_TABLE_STRUCT_FIELD(option_udp, filter)},
     };
 
     struct option_tcp {
@@ -717,7 +727,7 @@ static int parse_confs(ConfFile &conf)
                 ret = -EINVAL;
             } else {
                 ret = add_endpoint_address(iter.name + offset, iter.name_len - offset, opt_udp.addr,
-                                           opt_udp.port, opt_udp.eavesdropping);
+                                           opt_udp.port, opt_udp.eavesdropping, opt_udp.filter);
             }
         }
 

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -449,6 +449,7 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
         } else {
             _log_endpoint = new AutoLog(opt->logs_dir, opt->log_mode);
         }
+        _log_endpoint->mark_unfinished_logs();
         g_endpoints[i] = _log_endpoint;
     }
 

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -443,11 +443,14 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
 
     if (opt->logs_dir) {
         if (opt->mavlink_dialect == Ardupilotmega) {
-            _log_endpoint = new BinLog(opt->logs_dir, opt->log_mode);
+            _log_endpoint
+                = new BinLog(opt->logs_dir, opt->log_mode, opt->min_free_space, opt->max_log_files);
         } else if (opt->mavlink_dialect == Common) {
-            _log_endpoint = new ULog(opt->logs_dir, opt->log_mode);
+            _log_endpoint
+                = new ULog(opt->logs_dir, opt->log_mode, opt->min_free_space, opt->max_log_files);
         } else {
-            _log_endpoint = new AutoLog(opt->logs_dir, opt->log_mode);
+            _log_endpoint = new AutoLog(opt->logs_dir, opt->log_mode, opt->min_free_space,
+                                        opt->max_log_files);
         }
         _log_endpoint->mark_unfinished_logs();
         g_endpoints[i] = _log_endpoint;

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -132,12 +132,12 @@ int Mainloop::write_msg(Endpoint *e, const struct buffer *buf)
 }
 
 void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid, int sender_sysid,
-                         int sender_compid)
+                         int sender_compid, uint32_t msg_id)
 {
     bool unknown = true;
 
     for (Endpoint **e = g_endpoints; *e != nullptr; e++) {
-        if ((*e)->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid)) {
+        if ((*e)->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id)) {
             log_debug("Endpoint [%d] accepted message to %d/%d from %u/%u", (*e)->fd, target_sysid,
                       target_compid, sender_sysid, sender_compid);
             write_msg(*e, buf);
@@ -146,7 +146,7 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
     }
 
     for (struct endpoint_entry *e = g_tcp_endpoints; e; e = e->next) {
-        if (e->endpoint->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid)) {
+        if (e->endpoint->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id)) {
             log_debug("Endpoint [%d] accepted message to %d/%d from %u/%u", e->endpoint->fd,
                       target_sysid, target_compid, sender_sysid, sender_compid);
             int r = write_msg(e->endpoint, buf);
@@ -399,6 +399,14 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
             if (udp->open(conf->address, conf->port, conf->eavesdropping) < 0) {
                 log_error("Could not open %s:%ld", conf->address, conf->port);
                 return false;
+            }
+
+            if (conf->filter) {
+                char *token = strtok(conf->filter, ",");
+                while (token != NULL) {
+                    udp->add_message_to_filter(atoi(token));
+                    token = strtok(NULL, ",");
+                } 
             }
 
             g_endpoints[i] = udp.release();

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -130,4 +130,6 @@ struct options {
     LogMode log_mode;
     int debug_log_level;
     enum mavlink_dialect mavlink_dialect;
+    unsigned long min_free_space;
+    unsigned long max_log_files;
 };

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -36,7 +36,7 @@ public:
     int remove_fd(int fd);
     void loop();
     void route_msg(struct buffer *buf, int target_sysid, int target_compid, int sender_sysid,
-                   int sender_compid);
+                   int sender_compid, uint32_t msg_id = UINT32_MAX);
     void handle_read(Endpoint *e);
     void handle_canwrite(Endpoint *e);
     void handle_tcp_connection();
@@ -117,6 +117,7 @@ struct endpoint_config {
             bool flowcontrol;
         };
     };
+    char *filter;
 };
 
 struct options {

--- a/src/mavlink-router/ulog.h
+++ b/src/mavlink-router/ulog.h
@@ -23,8 +23,8 @@
 
 class ULog : public LogEndpoint {
 public:
-    ULog(const char *logs_dir, LogMode mode)
-        : LogEndpoint{"ULog", logs_dir, mode}
+    ULog(const char *logs_dir, LogMode mode, unsigned long min_free_space, unsigned long max_files)
+        : LogEndpoint{"ULog", logs_dir, mode, min_free_space, max_files}
     {
     }
 


### PR DESCRIPTION
Added two configuration options in the conf files: `MinFreeSpace` and `MaxLogFiles`. If there are less than `MinFreeSpace` bytes available on the device used for log storage, or if there are more than `MaxLogFiles` in the log directory, then files will be deleted. They are deleted in the order of their numerical index (the 5-digit number at the beginning of every log filename, before the timestamp), until both limits are met.

Both limits can be disabled by setting them to 0. 