### PR TITLE
Update to latest mavlink and fix API changes

### DIFF
--- a/src/mavlink-router/binlog.cpp
+++ b/src/mavlink-router/binlog.cpp
@@ -126,8 +126,8 @@ int BinLog::write_msg(const struct buffer *buffer)
         return buffer->len;
     }
 
-    if (payload_len > msg_entry->msg_len) {
-        payload_len = msg_entry->msg_len;
+    if (payload_len > msg_entry->max_msg_len) {
+        payload_len = msg_entry->max_msg_len;
     }
 
     if (mavlink2) {

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -413,10 +413,10 @@ uint8_t Endpoint::get_trimmed_zeros(const mavlink_msg_entry_t *msg_entry, const 
         return 0;
 
     /* Should never happen but if happens it will cause stack overflow */
-    if (msg->payload_len > msg_entry->msg_len)
+    if (msg->payload_len > msg_entry->max_msg_len)
         return 0;
 
-    return msg_entry->msg_len - msg->payload_len;
+    return msg_entry->max_msg_len - msg->payload_len;
 }
 
 void Endpoint::log_aggregate(unsigned int interval_sec)

--- a/src/mavlink-router/ulog.cpp
+++ b/src/mavlink-router/ulog.cpp
@@ -151,8 +151,8 @@ int ULog::write_msg(const struct buffer *buffer)
         return buffer->len;
     }
 
-    if (payload_len > msg_entry->msg_len) {
-        payload_len = msg_entry->msg_len;
+    if (payload_len > msg_entry->max_msg_len) {
+        payload_len = msg_entry->max_msg_len;
     }
 
     if (mavlink2) {


### PR DESCRIPTION
Ran into issues with a WIP message being dropped due to CRC not matching, noticed this hasn't been updated in a long time.

API changed here: https://github.com/ArduPilot/pymavlink/commit/8481afb968c384fb3f260ea5fe6e0b2e0f0b1c41