### PR TITLE
Add pipe command to remove dynamic endpoint

### DIFF
--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -98,6 +98,7 @@ private:
     bool _retry_timeout_cb(void *data);
     bool _log_aggregate_timeout(void *data);
     bool _add_dynamic_endpoint(std::string name, std::string command, Endpoint *endpoint);
+    bool _remove_dynamic_endpoint(std::string name);
     void _handle_pipe();
 
     Mainloop() { }


### PR DESCRIPTION
Current implementation listens on a pipe for commands. Currently the command for adding dynamic endpoints is supported.
This PR adds also "remove" command which removes dynamic endpoint by name.
Needed by pairing manager to stop sending telemetry when it enters pairing mode.