### PR TITLE
sysID exclusion

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -296,6 +296,10 @@ void Endpoint::_add_sys_comp_id(uint16_t sys_comp_id)
 
 bool Endpoint::has_sys_id(unsigned sysid)
 {
+    //-- If we don't have a sysID for this endpoint, we can't exclude it.
+    if(!_sys_comp_ids.size()) {
+        return true;
+    }
     for (auto it = _sys_comp_ids.begin(); it != _sys_comp_ids.end(); it++) {
         if (((*it >> 8) | (sysid & 0xff)) == sysid)
             return true;


### PR DESCRIPTION
The router code checks to see if the target endpoint sysID should be excluded or not based on the command/message. However, if it never received anything on that endpoint, it does not know of any sysID and the existing logic was to always reject.

The Vantage Snap sends MAVLink through one port and receives on another. When going through the router, the receiving port endpoint having never sent anything, would always get excluded. That caused commands sent to it never to go through.

This is a hack at best as I do not fully understand all the gyrations this code is going through. Don't merge it unless it's fully tested on a _normal_ system.
