### PR TITLE
parse correctly multiple commands written into the pipe

### DIFF
--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -514,7 +514,7 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
                 while (token != nullptr) {
                     udp->add_message_to_filter(atoi(token));
                     token = strtok(nullptr, ",");
-                } 
+                }
             }
 
             g_endpoints[i] = udp.release();
@@ -758,44 +758,58 @@ void Mainloop::_handle_pipe()
     if (num_read > 0) {
         cmd[num_read] = 0;
         log_debug("Pipe read %ld bytes: %s", num_read, cmd);
-        // Op UDP Name IP Port Eavesdropping
-        std::vector<std::string> a;
-        std::string command = cmd;
-        char *pch = strtok(cmd, " ");
-        while (pch != nullptr) {
-            a.emplace_back(pch);
-            pch = strtok(nullptr, " \n");
+
+        // if more than one command separated by an end of
+        // line was written in the pipe, separate each command
+        std::vector<char*> command_vector;
+        char *pch = strtok(cmd, "\n");
+        while (pch != nullptr ) {
+            command_vector.push_back(pch);
+            pch = strtok(nullptr, "\n");
         }
 
-        if (a.size() == 2 && a[0] == "remove") {
-            _remove_dynamic_endpoint(a[1]);
-            return;
-        }
+        for (auto command : command_vector) {
+          // Parse each command
+          // Command Format:
+          // Cmd UDP Name IP Port Eavesdropping
+          // e.g. add udp application 127.0.0.1 14532 0
+          std::vector<std::string> a;
+          pch = strtok(command, " ");
+          while (pch != nullptr) {
+              a.emplace_back(pch);
+              pch = strtok(nullptr, " \n");
+          }
 
-        if (a.size() != 6 || a[0] != "add" || a[1] != "udp") {
-            return;
-        }
-        std::string name = a[2];
-        std::string address = a[3];
-        int port = atoi(a[4].c_str());
-        if (port <= 0) {
-            return;
-        }
+          if (a.size() == 2 && a[0] == "remove") {
+              _remove_dynamic_endpoint(a[1]);
+              continue;
+          }
 
-        auto pipecmd = _pipe_commands.find(name);
-        if (pipecmd != _pipe_commands.end() && pipecmd->second == command) {
-            auto ep = _dynamic_endpoints.find(name);
-            if (ep != _dynamic_endpoints.end()) {
-                ep->second->reset_expire_timer();
-                return;
-            }
-        }
+          if (a.size() != 6 || a[0] != "add" || a[1] != "udp") {
+              continue;
+          }
+          std::string name = a[2];
+          std::string address = a[3];
+          int port = atoi(a[4].c_str());
+          if (port <= 0) {
+              continue;
+          }
 
-        std::unique_ptr<UdpEndpoint> udp{new UdpEndpoint()};
-        if (udp->open(address.c_str(), port, a[5]=="1") < 0) {
-            log_error("Could not open %s:%d", address.c_str(), port);
-            return;
+          auto pipecmd = _pipe_commands.find(name);
+          if (pipecmd != _pipe_commands.end() && pipecmd->second == command) {
+              auto ep = _dynamic_endpoints.find(name);
+              if (ep != _dynamic_endpoints.end()) {
+                  ep->second->reset_expire_timer();
+                  continue;
+              }
+          }
+
+          std::unique_ptr<UdpEndpoint> udp{new UdpEndpoint()};
+          if (udp->open(address.c_str(), port, a[5]=="1") < 0) {
+              log_error("Could not open %s:%d", address.c_str(), port);
+              continue;
+          }
+          _add_dynamic_endpoint(name, command, udp.release());
         }
-        _add_dynamic_endpoint(name, command, udp.release());
     }
 }

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -764,9 +764,8 @@ void Mainloop::_handle_pipe()
         // line was written in the pipe, separate each command
         char* current_new_line = strchr(buffer, '\n');
         while (current_new_line != NULL) {
-          char command[1024] = {0};
-          strncpy(command, buffer, current_new_line - buffer);
-
+          *current_new_line = '\0';
+          char *command = buffer;
           buffer = current_new_line+1;
           current_new_line = strchr(buffer, '\n');
 

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -755,26 +755,27 @@ void Mainloop::_handle_pipe()
 {
     char cmd[1024];
     ssize_t num_read = read(_pipefd, cmd, sizeof(cmd) - 1);
+    char* buffer = cmd;
     if (num_read > 0) {
         cmd[num_read] = 0;
         log_debug("Pipe read %ld bytes: %s", num_read, cmd);
 
-        // if more than one command separated by an end of
+        // If more than one command separated by an end of
         // line was written in the pipe, separate each command
-        std::vector<char*> command_vector;
-        char *pch = strtok(cmd, "\n");
-        while (pch != nullptr ) {
-            command_vector.push_back(pch);
-            pch = strtok(nullptr, "\n");
-        }
+        char* current_new_line = strchr(buffer, '\n');
+        while (current_new_line != NULL) {
+          char command[1024] = {0};
+          strncpy(command, buffer, current_new_line - buffer);
 
-        for (auto command : command_vector) {
+          buffer = current_new_line+1;
+          current_new_line = strchr(buffer, '\n');
+
           // Parse each command
           // Command Format:
           // Cmd UDP Name IP Port Eavesdropping
           // e.g. add udp application 127.0.0.1 14532 0
           std::vector<std::string> a;
-          pch = strtok(command, " ");
+          char *pch = strtok(command, " ");
           while (pch != nullptr) {
               a.emplace_back(pch);
               pch = strtok(nullptr, " \n");


### PR DESCRIPTION
Parsing of multiple commands was not properly supported. Now when reading from the pipe
```bash
add udp app1 192.168.168.100 24550 0 
add udp app2 127.0.0.1 14531 0
```
it will correctly keep resetting both endpoints. Before only the first one was reset. 