### PR TITLE
[RFC] Wake HW serial device up before reading

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -651,6 +651,10 @@ int UartEndpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_c
 
 ssize_t UartEndpoint::_read_msg(uint8_t *buf, size_t len)
 {
+    // On some hardware-serial interfaces, it is necessary to kick the device
+    // before reading from it, otherwise we don't get any data
+    struct buffer dummy{0};
+    ssize_t p = ::write(fd, &dummy, 1);
     ssize_t r = ::read(fd, buf, len);
     if ((r == -1 && errno == EAGAIN) || r == 0)
         return 0;


### PR DESCRIPTION
On the a Snapdragon 845 I have found that we do not get any data out of the serial device until a write to the same device occurs.

I currently don't understand if this is "normal" or due to some misconfiguration in the BSP. Either way, I'd appreciate some expertise and creative ideas on how to solve this problem in a nicer way than this PR does.

Note: on the same chip, same BSP, using an FTDI over USB works perfectly without this hack