### PR TITLE
fix log rotation

### DIFF
--- a/src/mavlink-router/logendpoint.cpp
+++ b/src/mavlink-router/logendpoint.cpp
@@ -191,10 +191,10 @@ void LogEndpoint::_delete_old_logs()
     }
 
     // If the configured value for _min_free_space is 0, then we don't have to do anything special.
-    uint64_t bytes_to_delete = _min_free_space - free_space;
+    int64_t bytes_to_delete = _min_free_space - free_space;
     // If the configured value for _max_files is 0, then set this to -1 to indicate that we've
     // already deleted enough files.
-    uint64_t files_to_delete = _max_files > 0 ? file_map.size() - _max_files : -1;
+    int64_t files_to_delete = _max_files > 0 ? file_map.size() - _max_files : -1;
 
     log_debug("[Log Deletion] Files to delete: %ld", files_to_delete);
 


### PR DESCRIPTION
Issue: every time we armed something was deleting all logs on the vehicle. It was then narrowed down to mavlink router since it's one of the only applications touching these logs.

Bug: change bytes_to_delete and files_to_delete from uint64_t to int64_t, otherwise it cannot get a negative value. These values become negative in these two lines I change when there is enough space, but they will be then seen as massive positive numbers due to the sign bit. This was difficult to find because the prints all use %ld, therefore in the print the number were negative. 

FYI @bkueng @ItsTimmy 