### PR TITLE
Add packet-coalescing algorithm for UDP endpoints

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -326,8 +326,8 @@ bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid
     if (has_sys_comp_id(src_sysid, src_compid))
         return false;
 
-    if (msg_id != UINT32_MAX && 
-        _message_filter.size() > 0 && 
+    if (msg_id != UINT32_MAX &&
+        _message_filter.size() > 0 &&
         std::find(_message_filter.begin(), _message_filter.end(), msg_id) == _message_filter.end()) {
 
         // if filter is defined and message is not in the set then discard it

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -175,7 +175,7 @@ private:
 class UdpEndpoint : public Endpoint {
 public:
     UdpEndpoint();
-    virtual ~UdpEndpoint() {}
+    ~UdpEndpoint() override;
 
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -150,7 +150,7 @@ public:
         : Endpoint {"UART"}
     {
     }
-    virtual ~UartEndpoint();
+    ~UartEndpoint() override;
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }
 
@@ -185,13 +185,21 @@ public:
     struct sockaddr_in sockaddr;
 
 protected:
+
+    void _schedule_write();
+    int _force_write();
+    bool _write_scheduled;
+
+    Timeout* _write_schedule_timer = nullptr;
+    const unsigned int _max_packet_size, _max_timeout_ms;
+
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 };
 
 class TcpEndpoint : public Endpoint {
 public:
     TcpEndpoint();
-    ~TcpEndpoint();
+    ~TcpEndpoint() override;
 
     int accept(int listener_fd);
     int open(const char *ip, unsigned long port);


### PR DESCRIPTION
This is a packet coalescing implementation for UDP endpoints using a default of 1ms/1200B transmit thresholds. Before, especially when communicating over ethernet, each (on average) 40B Mavlink packet could end up in its own IP packet, amplifying traffic significantly.

I've tested that it still works for UDP, and I haven't noticed any performance regressions, but also haven't verified that it correctly coalesces UDP packets. Unit tests would be nice.

General design is:

- On receipt of data to send, push it into the TX buffer
- If there is no send event scheduled, schedule one to happen in 1ms
- If the buffer has more data than 1200B, write immediately

Theoretically, setting the send size threshold to 1 should give exactly the same performance as before, minus a single extra epoll wakeup on start.

