### PR TITLE
UDP send coalescing + 'nodelay' message ID support

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -350,6 +350,22 @@ bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid
     return false;
 }
 
+void Endpoint::postprocess_msg(int target_sysid, int target_compid, uint8_t src_sysid,
+                               uint8_t src_compid, uint32_t msg_id)
+{
+    // avoid unused variable messages
+    (void)target_sysid;
+    (void)target_compid;
+    (void)src_sysid;
+    (void)src_compid;
+
+    if (msg_id != UINT32_MAX && _message_nodelay.size() > 0 &&
+        std::find(_message_nodelay.begin(), _message_nodelay.end(), msg_id) != _message_nodelay.end()) {
+        // if filter is defined and message is not in the set then discard it
+        flush_pending_msgs();
+    }
+}
+
 bool Endpoint::_check_crc(const mavlink_msg_entry_t *msg_entry)
 {
     const bool mavlink2 = rx_buf.data[0] == MAVLINK_STX;
@@ -697,9 +713,28 @@ int UartEndpoint::add_speeds(std::vector<unsigned long> bauds)
 }
 
 UdpEndpoint::UdpEndpoint()
-    : Endpoint{"UDP"}
+    : Endpoint{"UDP"},
+    _write_scheduled(false),
+    _max_packet_size(0),
+    _max_timeout_ms(0)
 {
     bzero(&sockaddr, sizeof(sockaddr));
+    _write_schedule_timer = Mainloop::get_instance().add_timeout(
+        _max_timeout_ms, [this](void*)
+            {
+                flush_pending_msgs();
+                return true;
+            },
+        this);
+}
+
+
+UdpEndpoint::~UdpEndpoint()
+{
+    if (_write_schedule_timer) {
+        Mainloop::get_instance().del_timeout(_write_schedule_timer);
+        _write_schedule_timer = nullptr;
+    }
 }
 
 int UdpEndpoint::open(const char *ip, unsigned long port, bool to_bind)
@@ -746,6 +781,12 @@ fail:
     return -1;
 }
 
+void UdpEndpoint::set_coalescing(unsigned int bytes, unsigned int milliseconds)
+{
+    _max_packet_size = bytes;
+    _max_timeout_ms = milliseconds;
+}
+
 ssize_t UdpEndpoint::_read_msg(uint8_t *buf, size_t len)
 {
     socklen_t addrlen = sizeof(sockaddr);
@@ -761,14 +802,42 @@ ssize_t UdpEndpoint::_read_msg(uint8_t *buf, size_t len)
 
 int UdpEndpoint::write_msg(const struct buffer *pbuf)
 {
+    if (tx_buf.len > 0 && tx_buf.len + pbuf->len > _max_packet_size) {
+        flush_pending_msgs();
+    }
+
+    if (tx_buf.len + pbuf->len > TX_BUF_MAX_SIZE) {
+        log_debug("Dropping message, tx buffer full");
+        return 0;
+    }
+
+    memcpy(&tx_buf.data[tx_buf.len], pbuf->data, pbuf->len);
+    tx_buf.len += pbuf->len;
+
+    int ret = pbuf->len;
+
+    if (_max_packet_size == 0 || _max_timeout_ms == 0 || pbuf->len > _max_packet_size) {
+       ret = flush_pending_msgs();
+    }
+    else {
+        _schedule_write();
+    }
+    return ret;
+}
+
+int UdpEndpoint::flush_pending_msgs()
+{
+    Mainloop::get_instance().set_timeout(_write_schedule_timer, 0);
+    _write_scheduled = false;
+
+    if (tx_buf.len == 0) {
+        log_debug("No data in tx buffer, skipping write");
+        return 0;
+    }
+
     if (fd < 0) {
         log_error("Trying to write invalid fd");
         return -EINVAL;
-    }
-
-    /* TODO: send any pending data */
-    if (tx_buf.len > 0) {
-        ;
     }
 
     if (!sockaddr.sin_port) {
@@ -776,7 +845,7 @@ int UdpEndpoint::write_msg(const struct buffer *pbuf)
         return 0;
     }
 
-    ssize_t r = ::sendto(fd, pbuf->data, pbuf->len, 0,
+    ssize_t r = ::sendto(fd, tx_buf.data, tx_buf.len, 0,
                          (struct sockaddr *)&sockaddr, sizeof(sockaddr));
     if (r == -1) {
         if (errno != EAGAIN && errno != ECONNREFUSED && errno != ENETUNREACH)
@@ -785,17 +854,23 @@ int UdpEndpoint::write_msg(const struct buffer *pbuf)
     };
 
     _stat.write.total++;
-    _stat.write.bytes += pbuf->len;
+    _stat.write.bytes += r;
 
-    /* Incomplete packet, we warn and discard the rest */
-    if (r != (ssize_t) pbuf->len) {
-        _incomplete_msgs++;
-        log_debug("Discarding packet, incomplete write %zd but len=%u", r, pbuf->len);
-    }
+    tx_buf.len = std::max(ssize_t(0), (ssize_t)tx_buf.len - r);
+    // memcpy isn't safe for overlapping regions
+    memmove(tx_buf.data, &tx_buf.data[r], tx_buf.len);
 
     log_debug("UDP: [%d] wrote %zd bytes", fd, r);
 
     return r;
+}
+
+void UdpEndpoint::_schedule_write()
+{
+    if (!_write_scheduled) {
+        Mainloop::get_instance().set_timeout(_write_schedule_timer, _max_timeout_ms);
+        _write_scheduled = true;
+    }
 }
 
 TcpEndpoint::TcpEndpoint()
@@ -924,3 +999,4 @@ void TcpEndpoint::close()
 
     fd = -1;
 }
+

--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -326,8 +326,8 @@ bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid
     if (has_sys_comp_id(src_sysid, src_compid))
         return false;
 
-    if (msg_id != UINT32_MAX && 
-        _message_filter.size() > 0 && 
+    if (msg_id != UINT32_MAX &&
+        _message_filter.size() > 0 &&
         std::find(_message_filter.begin(), _message_filter.end(), msg_id) == _message_filter.end()) {
 
         // if filter is defined and message is not in the set then discard it

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -150,7 +150,7 @@ public:
         : Endpoint {"UART"}
     {
     }
-    virtual ~UartEndpoint();
+    ~UartEndpoint() override;
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }
 
@@ -185,13 +185,21 @@ public:
     struct sockaddr_in sockaddr;
 
 protected:
+
+    void _schedule_write();
+    int _force_write();
+    bool _write_scheduled;
+
+    Timeout* _write_schedule_timer = nullptr;
+    const unsigned int _max_packet_size, _max_timeout_ms;
+
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 };
 
 class TcpEndpoint : public Endpoint {
 public:
     TcpEndpoint();
-    ~TcpEndpoint();
+    ~TcpEndpoint() override;
 
     int accept(int listener_fd);
     int open(const char *ip, unsigned long port);

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -160,7 +160,10 @@ struct endpoint_config {
             char *address;
             long unsigned port;
             int retry_timeout;
-            bool eavesdropping;
+            bool eavesdropping;     // bind to local port specified, instead of send to remote port
+            int coalesce_ms;        // max time to hold data to try to send packets together
+            int coalesce_bytes;     // never send packets larger than this size
+            char *coalesce_nodelay; // immediately send if a mavlink msg_id is matching this
         };
         struct {
             char *device;

--- a/src/mavlink-router/mainloop_test.cpp
+++ b/src/mavlink-router/mainloop_test.cpp
@@ -6,7 +6,7 @@
 
 class MainLoopTest : public ::testing::Test {
 public:
-    static struct endpoint_config make_udp_endpoint_config(int port)
+    static struct endpoint_config make_udp_endpoint_config(int port, bool coalesce)
     {
         struct endpoint_config cfg {};
         // XXX: need non-const strings here, despite the fact that this is
@@ -24,7 +24,14 @@ public:
         // XXX: not clear about the name of this variable -- it causes socket
         // to be bound to specified port
         cfg.eavesdropping = true;
+        if (coalesce) {
+            cfg.coalesce_bytes = 100;
+            cfg.coalesce_ms = 1;
+        }
         cfg.filter = nullptr;
+        static char nodelay[] = "75,76,77";
+        cfg.coalesce_nodelay = nodelay;
+
         return cfg;
     }
 
@@ -62,7 +69,7 @@ TEST_F(MainLoopTest, termination)
 
 TEST_F(MainLoopTest, create_udp_endpoint)
 {
-    struct endpoint_config cfg = make_udp_endpoint_config(7777);
+    struct endpoint_config cfg = make_udp_endpoint_config(7777, false);
     struct options opts = make_single_endpoint_options(&cfg);
 
     Mainloop mainloop;
@@ -72,7 +79,7 @@ TEST_F(MainLoopTest, create_udp_endpoint)
 
 TEST_F(MainLoopTest, direct_udp_endpoint_send)
 {
-    struct endpoint_config cfg = make_udp_endpoint_config(7777);
+    struct endpoint_config cfg = make_udp_endpoint_config(7777, false);
     struct options opts = make_single_endpoint_options(&cfg);
 
     Mainloop mainloop;
@@ -89,6 +96,155 @@ TEST_F(MainLoopTest, direct_udp_endpoint_send)
     char data[17] = "0123456789abcdef";
     struct buffer buf = {16, reinterpret_cast<uint8_t*>(data)};
     udp_endpoint->write_msg(&buf);
+
+    char recvbuf[1024];
+    ssize_t count = ::recv(sock, recvbuf, 1024, 0);
+
+    EXPECT_EQ(16, count);
+    EXPECT_EQ(0, std::memcmp("0123456789abcdef", recvbuf, 16));
+
+    ::close(sock);
+}
+
+
+TEST_F(MainLoopTest, direct_udp_endpoint_send_coalesce_time_trigger)
+{
+    struct endpoint_config cfg = make_udp_endpoint_config(7777, true);
+    struct options opts = make_single_endpoint_options(&cfg);
+
+    Mainloop mainloop;
+
+    // Set up and grab one udp endpoint
+    mainloop.add_endpoints(mainloop, &opts);
+    ASSERT_EQ(1, mainloop.endpoints().size());
+    UdpEndpoint* udp_endpoint = dynamic_cast<UdpEndpoint *>(mainloop.endpoints()[0].get());
+    ASSERT_NE(nullptr, udp_endpoint);
+
+    int sock;
+    std::tie(sock, udp_endpoint->sockaddr) = make_scratch_udp_socket();
+
+    char data[17] = "0123456789abcdef";
+    struct buffer buf = {16, reinterpret_cast<uint8_t*>(data)};
+    udp_endpoint->write_msg(&buf);
+
+    char recvbuf[1024];
+    ssize_t count = ::recv(sock, recvbuf, 1024, MSG_DONTWAIT);
+
+    EXPECT_EQ(-1, count) << "UDP packet coalescing shouldn't have allowed a send yet";
+    EXPECT_EQ(EWOULDBLOCK, errno);
+
+    // allow UDP packet coalescing to expire
+    // XXX: make the timer expire explicitly, instead of waiting for timeout
+    mainloop.run_single(100);
+
+    count = ::recv(sock, recvbuf, 1024, 0);
+
+    EXPECT_EQ(16, count);
+    EXPECT_EQ(0, std::memcmp("0123456789abcdef", recvbuf, 16));
+
+    ::close(sock);
+}
+
+TEST_F(MainLoopTest, direct_udp_endpoint_send_coalesce_size_trigger)
+{
+    struct endpoint_config cfg = make_udp_endpoint_config(7777, true);
+    struct options opts = make_single_endpoint_options(&cfg);
+
+    Mainloop mainloop;
+
+    // Set up and grab one udp endpoint
+    mainloop.add_endpoints(mainloop, &opts);
+    ASSERT_EQ(1, mainloop.endpoints().size());
+    UdpEndpoint* udp_endpoint = dynamic_cast<UdpEndpoint *>(mainloop.endpoints()[0].get());
+    ASSERT_NE(nullptr, udp_endpoint);
+
+    int sock;
+    std::tie(sock, udp_endpoint->sockaddr) = make_scratch_udp_socket();
+
+    char data[110] = {};
+    for (int i = 1; i < 110; i++) data[i] = i;
+
+    const struct buffer buf = {110, reinterpret_cast<uint8_t*>(data)};
+    udp_endpoint->write_msg(&buf);
+
+    char recvbuf[1024];
+    ssize_t count = ::recv(sock, recvbuf, 1024, 0);
+
+    EXPECT_EQ(110, count);
+    EXPECT_EQ(0, std::memcmp(data, recvbuf, 110));
+
+    ::close(sock);
+}
+
+TEST_F(MainLoopTest, direct_udp_endpoint_send_coalesce_size_trigger_from_second)
+{
+    struct endpoint_config cfg = make_udp_endpoint_config(7777, true);
+    struct options opts = make_single_endpoint_options(&cfg);
+
+    Mainloop mainloop;
+
+    // Set up and grab one udp endpoint
+    mainloop.add_endpoints(mainloop, &opts);
+    ASSERT_EQ(1, mainloop.endpoints().size());
+    UdpEndpoint* udp_endpoint = dynamic_cast<UdpEndpoint *>(mainloop.endpoints()[0].get());
+    ASSERT_NE(nullptr, udp_endpoint);
+
+    int sock;
+    std::tie(sock, udp_endpoint->sockaddr) = make_scratch_udp_socket();
+
+    char data[55] = {};
+    for (int i = 1; i < 55; i++) data[i] = i;
+
+    struct buffer buf = {55, reinterpret_cast<uint8_t*>(data)};
+    udp_endpoint->write_msg(&buf);
+
+    char recvbuf[1024];
+    ssize_t count = ::recv(sock, recvbuf, 1024, MSG_DONTWAIT);
+
+    EXPECT_EQ(-1, count) << "UDP packet coalescing shouldn't have allowed a send yet";
+    EXPECT_EQ(EWOULDBLOCK, errno);
+
+    buf.len = 50;
+    udp_endpoint->write_msg(&buf);
+
+    count = ::recv(sock, recvbuf, 1024, 0);
+
+    EXPECT_EQ(55, count);
+    EXPECT_EQ(0, std::memcmp(data, recvbuf, 55));
+
+    // allow UDP packet coalescing to expire
+    // XXX: make the timer expire explicitly, instead of waiting for timeout
+    mainloop.run_single(100);
+
+    memset(recvbuf, 0, 1024);
+    count = ::recv(sock, recvbuf, 1024, 0);
+
+    EXPECT_EQ(50, count);
+    EXPECT_EQ(0, std::memcmp(data, recvbuf, 50));
+
+    ::close(sock);
+}
+
+TEST_F(MainLoopTest, direct_udp_endpoint_send_coalesce_nodelay)
+{
+    struct endpoint_config cfg = make_udp_endpoint_config(7777, true);
+    struct options opts = make_single_endpoint_options(&cfg);
+
+    Mainloop mainloop;
+
+    // Set up and grab one udp endpoint
+    mainloop.add_endpoints(mainloop, &opts);
+    ASSERT_EQ(1, mainloop.endpoints().size());
+    UdpEndpoint* udp_endpoint = dynamic_cast<UdpEndpoint *>(mainloop.endpoints()[0].get());
+    ASSERT_NE(nullptr, udp_endpoint);
+
+    int sock;
+    std::tie(sock, udp_endpoint->sockaddr) = make_scratch_udp_socket();
+
+    char data[17] = "0123456789abcdef";
+    struct buffer buf = {16, reinterpret_cast<uint8_t*>(data)};
+    udp_endpoint->write_msg(&buf);
+    udp_endpoint->postprocess_msg(0,0,0,0,76);
 
     char recvbuf[1024];
     ssize_t count = ::recv(sock, recvbuf, 1024, 0);


### PR DESCRIPTION
This is a packet coalescing implementation for UDP endpoints using time and size transmit thresholds. Before, especially when communicating over ethernet or wifi, each (on average) 40B Mavlink packet could end up in its own IP packet, amplifying traffic significantly. This can be worse on half-duplex links, where a single packet in one direction may prevent the frame from being used for critical communications in the other direction..

Delay, coalescing, nodelay mechanism is unit tested, and the file parsing for all 3 fields has been manually tested.

General design is:

    On receipt of data to send, push it into the TX buffer
    
    If the buffer has more data than Y, 
     or the timeout is set to 0,
     or if the message was in the NoDelay list,
        write immediately
    Else if there is no send event scheduled, schedule one to happen in X

Theoretically, setting the send size threshold to 0 should give exactly the same performance as before, minus a couple of comparisons and an extra memcpy per packet.

This feature can be accessed by adding the following parameters to the config file under a UDP endpoint (example values populated):

```
#1200 bytes is a bit less than 1500 for ethernet
CoalesceBytes = 1200

#60ms probably isn't noticeable for telemetry on the groundstation
CoalesceMs = 60

#these are the mavlink IDs for messages COMMAND_INT, COMMAND_LONG and COMMAND_ACK
CoalesceNoDelay = 75,76,77
```