### PR TITLE
Dynamic endpoints coalescing

### DIFF
--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -213,7 +213,7 @@ fail:
 
 static int add_udp_endpoint_address(const char *name, size_t name_len, const char *ip,
                                     long unsigned port, bool eavesdropping, const char *filter,
-                                    int coalesce_ms, int coalesce_bytes, const char *coalesce_nodelay)
+                                    int coalesce_bytes, int coalesce_ms, const char *coalesce_nodelay)
 {
     int ret;
 

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -147,6 +147,7 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
             log_debug("Endpoint [%d] accepted message to %d/%d from %u/%u", e->fd, target_sysid,
                       target_compid, sender_sysid, sender_compid);
             write_msg(e.get(), buf);
+            e->postprocess_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id);
             unknown = false;
         }
     }
@@ -157,6 +158,7 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
                       target_compid, sender_sysid, sender_compid);
             write_msg(i.second, buf);
             unknown = false;
+            i.second->postprocess_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id);
         }
     }
 

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -81,10 +81,10 @@ public:
     void del_timeout(Timeout *t);
 
     bool add_endpoints(Mainloop &mainloop, struct options *opt);
-    bool remove_dynamic_endpoint(Endpoint *endpoint);
 
     bool add_dynamic_endpoint(const dynamic_command& command);
     bool remove_dynamic_endpoint(const dynamic_command& command);
+    bool remove_dynamic_endpoint(Endpoint *endpoint);
 
     void print_statistics();
 
@@ -109,6 +109,13 @@ public:
     inline const std::vector<std::unique_ptr<Endpoint>>& endpoints() const
     {
         return _endpoints;
+    }
+
+    /*
+     * Expose lsit of registered dynamic endpoints (mostly for tests)
+     */
+    inline const std::map<std::string, Endpoint *>& dynamic_endpoints() const {
+        return _dynamic_endpoints;
     }
 
     static int parse(const char* cmd_string, dynamic_command& cmd);


### PR DESCRIPTION
Mavlink router supports dynamic endpoints. These have a separate parsing mechanism from the config file, and live separately too.

This PR adds support to the parsing of dynamic endpoints for the coalescing. It also calls the post-process for the coalescing on dynamic endpoints.

@caleridas not sure how to test this without another giant refactor, but unix pipes really aren't my thing, so maybe I'm missing something.

@nicovanduijn @MatejFranceskin FYI

Follow up to https://github.com/Auterion/mavlink-router/pull/23