### PR TITLE
Log coalescing parameters when adding dynamic endpoint

### DIFF
--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -456,7 +456,7 @@ bool Mainloop::add_dynamic_endpoint(const dynamic_command& command)
         endpoint->add_message_to_nodelay(id);
     }
 
-    log_info("Adding dynamic endpoint: %s", command.name.c_str());
+    log_info("Adding dynamic endpoint: %s - coalesce %d bytes %d ms", command.name.c_str(), command.coalesce_bytes, command.coalesce_ms);
     auto ep = _dynamic_endpoints.find(command.name);
     if (ep != _dynamic_endpoints.end()) {
         remove_fd(ep->second->fd);


### PR DESCRIPTION
Add logging of coalescing parameters when creating dynamic endpoint to ease testing of pairing manager PR: https://github.com/Auterion/pairing-manager/pull/45