### PR TITLE
Filter incoming mavlink messages

### DIFF
--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -100,6 +100,7 @@ public:
     bool accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid, uint32_t msg_id);
     void postprocess_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid, uint32_t msg_id);
 
+    bool allowed_by_filter(uint32_t msg_id);
     void add_message_to_filter(uint32_t msg_id) { _message_filter.push_back(msg_id); }
     void add_message_to_nodelay(uint32_t msg_id) { _message_nodelay.push_back(msg_id); }
 

--- a/src/mavlink-router/ulog.cpp
+++ b/src/mavlink-router/ulog.cpp
@@ -201,8 +201,8 @@ int ULog::write_msg(const struct buffer *buffer)
         mavlink_msg_logging_ack_encode(LOG_ENDPOINT_SYSTEM_ID, MAV_COMP_ID_ALL, &msg, &ack);
         _send_msg(&msg, _target_system_id);
         /* message will be handled by MAVLINK_MSG_ID_LOGGING_DATA case */
-        /* fall through */
     }
+    /* fall through */
     case MAVLINK_MSG_ID_LOGGING_DATA: {
         if (trimmed_zeros) {
             mavlink_logging_data_t ulog_data;


### PR DESCRIPTION
This applies the same filter behavior to messages read from endpoints as it does to the messages sent to the endpoint.

Future extension (if needed): have a separate filter for reading as for writing, and fall back to this one if the separate reading filter isn't populated.