### PR TITLE
Fix MAV_CMD not being passed to camera managers

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -324,11 +324,6 @@ bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid
         }
     }
 
-    // This endpoint sent the message, we don't want to send it back over the
-    // same channel to avoid loops: reject
-    if (has_sys_comp_id(src_sysid, src_compid))
-        return false;
-
     if (!allowed_by_filter(msg_id))
         return false;
 


### PR DESCRIPTION
**Problem Description**
It seems like the problem is that the camera manager gets registered in the source sys/comp id. The registered source sysid/compid is 1/1(autopilot) and 1/100(payload manager). Therefore, if your src_sys_id and component ID is in the list it doesn't get sent to the endpoints in the list. Therefore mavlink messages from the autopilot does not make it to the payload manager

https://github.com/Auterion/mavlink-router/blob/auterion-router-latest/src/mavlink-router/endpoint.cpp#L327-L330

**Solution**
This PR removes the check `has_sys_id` in order to not filter out messages moving from the fmu to the camera manager

![image](https://user-images.githubusercontent.com/5248102/98790082-7caac400-2403-11eb-9803-5b452a1f538f.png)
