### PR TITLE
Add optional dropout percentage for UDP and UART

### DIFF
--- a/src/common/conf_file.cpp
+++ b/src/common/conf_file.cpp
@@ -347,8 +347,8 @@ int ConfFile::_extract_options_from_section(struct section *s, const OptionsTabl
         storage = (void *)((char *)data + table[i].storage.offset);
         ret = table[i].parser_func(c->value, c->value_len, storage, table[i].storage.len);
         if (ret < 0) {
-            log_error("On file %s: Line %d: Invalid value '%.*s' for field '%s'", c->filename,
-                      c->line, (int)c->value_len, c->value, table[i].key);
+            log_error("On file %s: Line %d: Invalid value '%.*s' for field '%s', err %d", c->filename,
+                      c->line, (int)c->value_len, c->value, table[i].key, ret);
             return ret;
         }
     }

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -103,6 +103,8 @@ public:
     bool allowed_by_filter(uint32_t msg_id);
     void add_message_to_filter(uint32_t msg_id) { _message_filter.push_back(msg_id); }
     void add_message_to_nodelay(uint32_t msg_id) { _message_nodelay.push_back(msg_id); }
+    bool allowed_by_dropout();
+    void set_dropout_percentage (uint32_t dropout_percentage) { _dropout_percentage = dropout_percentage; }
 
     void start_expire_timer();
 
@@ -129,6 +131,7 @@ protected:
 
     std::string _name;
     size_t _last_packet_len = 0;
+    uint32_t _dropout_percentage = 0;
 
     // Statistics
     struct {

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -503,6 +503,11 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
                     return false;
             }
 
+            if (conf->dropout_percentage) {
+                log_warning("Dropout set to %u%% on uart %s", conf->dropout_percentage, conf->device);
+                uart->set_dropout_percentage(conf->dropout_percentage);
+            }
+
             mainloop.add_fd(uart->fd, uart.get(), EPOLLIN);
             _endpoints.push_back(std::move(uart));
             break;
@@ -534,6 +539,11 @@ bool Mainloop::add_endpoints(Mainloop &mainloop, struct options *opt)
                     token = strtok(nullptr, ",");
                 }
                 free(local_nodelay);
+            }
+
+            if (conf->dropout_percentage) {
+                log_warning("Dropout set to %u%% on udp %s:%lu", conf->dropout_percentage, conf->address, conf->port);
+                udp->set_dropout_percentage(conf->dropout_percentage);
             }
 
             mainloop.add_fd(udp->fd, udp.get(), EPOLLIN);

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -192,6 +192,7 @@ struct endpoint_config {
         };
     };
     char *filter;
+    uint32_t dropout_percentage;
 };
 
 struct options {


### PR DESCRIPTION
In order to test lossy links, it is useful to be able to simulate dropped packets without having to introduce a genuine lossy link (eg. RF, or congested UDP link) into the system.

This PR adds an option to the mavlink router configuration, allowing to specify DropoutPercentage to artifically drop that percentage of incoming or outgoing packets on that interface, on both UDP and UART links.