### PR TITLE
LogEndpoint: close the file when receiving the ack from the stop command

### DIFF
--- a/src/mavlink-router/binlog.cpp
+++ b/src/mavlink-router/binlog.cpp
@@ -43,7 +43,7 @@ bool BinLog::_stop_timeout()
 {
     // TODO: Stop timeout not implemented for binlog, see example in ulog
     _remove_stop_timeout();
-    return true;
+    return false;
 }
 
 bool BinLog::start()

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <memory>
 #include <vector>
+#include <string>
 
 #include "comm.h"
 #include "pollable.h"

--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -89,6 +89,8 @@ protected:
     void _handle_auto_start_stop(uint32_t msg_id, uint8_t source_system_id,
             uint8_t source_component_id, uint8_t *payload);
 
+    virtual void _close_file();
+
 private:
     int _get_file(const char *extension);
     uint32_t _get_prefix(DIR *dir);

--- a/src/mavlink-router/ulog.cpp
+++ b/src/mavlink-router/ulog.cpp
@@ -85,7 +85,7 @@ bool ULog::start()
     return true;
 }
 
-void ULog::stop()
+void ULog::_close_file()
 {
     if (_file == -1) {
         log_info("ULog not started");
@@ -98,8 +98,7 @@ void ULog::stop()
         if (!_logging_flush())
             break;
     }
-
-    LogEndpoint::stop();
+    LogEndpoint::_close_file();
 }
 
 int ULog::write_msg(const struct buffer *buffer)
@@ -184,9 +183,10 @@ int ULog::write_msg(const struct buffer *buffer)
                 }
             } else if (_logging_stop_timeout && cmd.command == MAV_CMD_LOGGING_STOP) {
                 _remove_stop_timeout();
+                _close_file();
             }
 
-        } else
+        } else if (cmd.result != MAV_RESULT_IN_PROGRESS)
             log_error("MAV_CMD_LOGGING_%s result(%u) is different than accepted",cmd.command==MAV_CMD_LOGGING_START ? "START" : "STOP", cmd.result);
         break;
     }

--- a/src/mavlink-router/ulog.h
+++ b/src/mavlink-router/ulog.h
@@ -29,7 +29,6 @@ public:
     }
 
     bool start() override;
-    void stop() override;
 
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override { return -ENOSYS; }
@@ -38,6 +37,8 @@ protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override { return 0; };
     bool _start_timeout() override;
     bool _stop_timeout() override;
+
+    void _close_file() override;
 
     const char *_get_logfile_extension() override { return "ulg"; };
 private:


### PR DESCRIPTION
This allows the autopilot to send additional data when stopping.

Also reduces the stop timeout from 1s to 100ms.