### PR TITLE
Timeout timer - change to NONBLOCK otherwise we could hang in a timer read operation

### DIFF
--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -683,7 +683,7 @@ Timeout *Mainloop::add_timeout(uint32_t timeout_msec, std::function<bool(void*)>
 
     assert_or_return(t, nullptr);
 
-    t->fd = timerfd_create(CLOCK_MONOTONIC, 0);
+    t->fd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK);
     if (t->fd < 0) {
         log_error("Unable to create timerfd: %m");
         goto error;


### PR DESCRIPTION
This could happen if in the same group of events in the mainloop we have
and operation disarming the timer followed by a timer read. This is a
corner case that can happen more often when using mavlink message
coalescing since the timer is continuously used. When this issue occurs
the entire mavlink router mainloop is hanging since the timer read is
done in this loop.

Read where we could get stuck: https://github.com/Auterion/mavlink-router/blob/26afd98e432b5be33cd2f912bdaa14fa87416d07/src/mavlink-router/timeout.cpp#L34

FYI @nicovanduijn @mrivi since you both were affected. This issue is old but became much more likely when enabling coalescing. I am pretty sure that this is the issue you both hit.