### PR TITLE
logendpoint: increase fsync rate from 1Hz to 2Hz

### DIFF
--- a/src/mavlink-router/logendpoint.cpp
+++ b/src/mavlink-router/logendpoint.cpp
@@ -404,9 +404,9 @@ bool LogEndpoint::start()
         goto timeout_error;
     }
 
-    // Call fsync once per second
+    // Call fsync twice per second
     _fsync_timeout = Mainloop::get_instance().add_timeout(
-        MSEC_PER_SEC, std::bind(&LogEndpoint::_fsync, this), this);
+        MSEC_PER_SEC/2, std::bind(&LogEndpoint::_fsync, this), this);
     if (!_fsync_timeout) {
         log_error("Unable to add timeout");
         goto timeout_error;


### PR DESCRIPTION
Makes sure we lose less data in case of a crash/power loss.

looking at `/proc/diskstats`, the number of ms spent writing increases
from 26ms to 46ms per second.

CPU load is pretty much the same.

We'll need to check whether this negatively affects bandwidth for other use-cases.