### PR TITLE
WIP: PR for allowing hostnames in config files

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -881,7 +881,11 @@ int UdpEndpoint::open(const char *ip, unsigned long port, bool to_bind)
     } else {
 #endif
     sockaddr.sin_family = AF_INET;
-    sockaddr.sin_addr.s_addr = inet_addr(ip);
+    struct hostent *server;
+    server = gethostbyname(ip);
+    bcopy((char *)server->h_addr, 
+         (char *)&sockaddr.sin_addr.s_addr,
+         server->h_length);
     sockaddr.sin_port = htons(port);
 #ifdef ENABLE_IPV6
     }
@@ -1147,7 +1151,11 @@ int TcpEndpoint::open(const char *ip, unsigned long port)
     } else {
 #endif
     sockaddr.sin_family = AF_INET;
-    sockaddr.sin_addr.s_addr = inet_addr(ip);
+    struct hostent *server;
+    server = gethostbyname(ip);
+    bcopy((char *)server->h_addr, 
+         (char *)&sockaddr.sin_addr.s_addr,
+         server->h_length);
     sockaddr.sin_port = htons(port);
 #ifdef ENABLE_IPV6
     }

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -797,14 +797,9 @@ static int parse_confs(ConfFile &conf)
                 log_error("Expected 'port' key for section %.*s", (int)iter.name_len, iter.name);
                 ret = -EINVAL;
             } else {
-                if (validate_ip(opt_udp.addr) < 0) {
-                    log_error("Invalid IP address in section %.*s: %s", (int)iter.name_len, iter.name, opt_udp.addr);
-                    ret = -EINVAL;
-                } else {
                     ret = add_udp_endpoint_address(iter.name + offset, iter.name_len - offset, opt_udp.addr,
                                                    opt_udp.port, opt_udp.eavesdropping, opt_udp.filter, opt_udp.coalesce_bytes,
                                                    opt_udp.coalesce_ms, opt_udp.coalesce_nodelay, opt_udp.dropout_percentage);
-                }
             }
         }
 
@@ -823,13 +818,8 @@ static int parse_confs(ConfFile &conf)
         ret = conf.extract_options(&iter, option_table_tcp, ARRAY_SIZE(option_table_tcp), &opt_tcp);
 
         if (ret == 0) {
-            if (validate_ip(opt_tcp.addr) < 0) {
-                log_error("Invalid IP address in section %.*s: %s", (int)iter.name_len, iter.name, opt_tcp.addr);
-                ret = -EINVAL;
-            } else {
                 ret = add_tcp_endpoint_address(iter.name + offset, iter.name_len - offset, opt_tcp.addr,
                                                opt_tcp.port, opt_tcp.timeout);
-            }
         }
         free(opt_tcp.addr);
         if (ret < 0)


### PR DESCRIPTION
### Objective
To allow specification of hostnames (rather than just IP addresses) in mavlink-router config files.

### Context
It seems as if this feature isn't part of the upstream mavlink-router yet, either, but we're looking to be able to specify a hostname that can be resolved dynamically at runtime.  

The goal would be to allow configurations such as the following:
```
[UdpEndpoint qgroundcontrol]
Mode = Eavesdropping
Address = qgc.auterion.com
Port = 14551
```

The current result when using this config is:

`Invalid IP address in section UdpEndpoint qgroundcontrol: qgc.auterion.com`

### Current Status

Note that this initial patch is a WIP (i.e., it does not seem to add the feature properly); it was my best stab at making it work.  @TSC21 suggested I open a PR to get some feedback/help.  Thanks!