### PR TITLE
Write the version of AuterionOS to the ulog file.

### DIFF
--- a/src/mavlink-router/auterion_ulog_meta_writer.h
+++ b/src/mavlink-router/auterion_ulog_meta_writer.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <stdint.h>
+#include <fcntl.h>
+#include <fstream>
+#include <regex>
+
+
+class InformationMessage {
+private:
+    struct _packed_ Header {
+        uint16_t msg_size;
+        char msg_type;
+        uint8_t key_size;
+    };
+
+public:
+    static std::vector<char> encode(const std::string key, const std::string value) {
+        const std::string prepended_key = "char[" + std::to_string(value.size()) + "] " + key;
+        const std::string full_payload = prepended_key + value;
+        Header h;
+        h.msg_size = full_payload.size() + 1;
+        h.msg_type = 'I';
+        h.key_size = prepended_key.size();
+        std::vector<char> result;
+        std::copy((char*)(&h), (char*)(&h)+sizeof(h), std::back_inserter(result));
+        std::copy(full_payload.begin(), full_payload.end(), std::back_inserter(result));
+        return result;
+    }
+};
+
+
+bool get_aos_version(std::string &version) {
+    std::ifstream infile("/etc/release.conf");
+    if (!infile.good()) {
+        infile.close();
+        return false;
+    }
+
+    const std::regex regex{"^Version: (.*)"};
+    std::string line;
+    
+    while (std::getline(infile, line)) {
+        std::smatch match;
+        if (std::regex_search(line, match, regex)) {
+            version = match[1];
+            infile.close();
+            return true;
+        }
+    }
+    infile.close();
+    return false;
+};
+
+
+
+
+bool write_meta_information(int file, bool &meta_written) {
+
+    std::string version;
+    if (!get_aos_version(version)) {
+        log_warning("Could not read AuterionOS version file!");
+        meta_written = true;
+        return true;
+    }
+    const auto messages = InformationMessage::encode("aos_version", version);
+
+
+    ssize_t total_length = messages.size();
+    ssize_t written = 0;
+    while (written < total_length) {
+        ssize_t r = write(file, messages.data() + written, total_length - written);
+        if (r == 0 || (r == -1 && errno == EAGAIN))
+            return true;
+        if (r < 0) {
+            log_error("Unable to write to ULog file: (%m)");
+            return false;
+        }
+        written += r;
+    }
+    meta_written = true;
+    return true;
+}

--- a/src/mavlink-router/ulog.cpp
+++ b/src/mavlink-router/ulog.cpp
@@ -25,6 +25,7 @@
 
 #include <common/log.h>
 #include <common/util.h>
+#include "auterion_ulog_meta_writer.h"
 
 #define ULOG_HEADER_SIZE 16
 #define ULOG_MAGIC                               \
@@ -74,7 +75,6 @@ bool ULog::start()
     if (!LogEndpoint::start()) {
         return false;
     }
-
     _waiting_header = true;
     _waiting_first_msg_offset = false;
     _expected_seq = 0;
@@ -351,12 +351,21 @@ bool ULog::_logging_flush()
         memmove(_buffer_partial, &_buffer_partial[r], _buffer_partial_len);
     }
 
+    if (!_waiting_flags && !_meta_written) {
+        write_meta_information(_file, _meta_written);
+    }
+
     while (_buffer_len >= sizeof(struct ulog_msg_header) && !_buffer_partial_len) {
         struct ulog_msg_header *header = (struct ulog_msg_header *)&_buffer[_buffer_index];
         const uint16_t full_msg_size = header->msg_size + sizeof(struct ulog_msg_header);
+        const char msg_type = header->msg_type;
 
         if (full_msg_size > _buffer_len) {
             break;
+        }
+
+        if (msg_type == 'B') {
+            _waiting_flags = false;
         }
 
         const ssize_t r = write(_file, header, full_msg_size);

--- a/src/mavlink-router/ulog.h
+++ b/src/mavlink-router/ulog.h
@@ -44,6 +44,8 @@ protected:
 private:
     uint16_t _expected_seq = 0;
     bool _waiting_header = true;
+    bool _waiting_flags = true;
+    bool _meta_written = false;
     bool _waiting_first_msg_offset = false;
 
     uint8_t _buffer[BUFFER_LEN];


### PR DESCRIPTION
#### Describe your solution
This mavlink router writes the AuterionOS version into the streamed ulog file. This is not a great solution for now, but it does solve immediate needs. 


#### Test data / coverage
How was this tested? What Platforms were covered?
* Skynode 


#### Additional information
To test:
1. Install mavlink router from this PR
2. Arm / disarm drone