### PR TITLE
mainloop: don't remove pipe

### DIFF
--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -68,7 +68,6 @@ Mainloop::~Mainloop()
         ::close(_pipefd);
         _pipefd = -1;
     }
-    ::remove(pipe_path);
     instance = nullptr;
 }
 


### PR DESCRIPTION
When mavlink-router is stopped, don't remove the pipe. The other services writing into that pipe don't get notified that mavlink-router closed it. Furthermore the write doesn't fail as the file isn't deleted by the linux kernel as there is still at least one file descriptor pointing to it. 