### PR TITLE
TCP: Do not quit on EPOLLERR & EPOLLHUP

### DIFF
--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -364,11 +364,18 @@ int Mainloop::run_single(int timeout_msec)
             }
         }
         if (events[i].events & EPOLLERR) {
-            log_error("poll error for fd %i, closing it", p->fd);
-            remove_fd(p->fd);
-            // make poll errors fatal so that an external component can
-            // restart mavlink-router
-            request_exit();
+            if (events[i].events & EPOLLHUP) {
+                // EPOLLHUP is an expected error, in case the TCP connection
+                // drops. In this case, we'll just need to clean up the TCP
+                // connection later, no need to panic.
+                should_process_tcp_hangups = true;
+            } else {
+                log_error("poll error for fd %i, closing it", p->fd);
+                remove_fd(p->fd);
+                // make poll errors fatal so that an external component can
+                // restart mavlink-router
+                request_exit();
+            }
         }
     }
 


### PR DESCRIPTION
EPOLLERR & EPOLLHUP would be exptected in TCP connections, when the connection drops from the client. Only handle this with subsequent cleanup of the connection, no need to panic here. 


Tested with this beautiful script that opens > 500 TCP connections to mavlink router. Works fine now:
[adverse.txt](https://github.com/Auterion/mavlink-router/files/10537385/adverse.txt)
