### PR TITLE
Endpoint: On CRC error, treat messages the same as unknown messages.

### DIFF
--- a/src/mavlink-router/endpoint.cpp
+++ b/src/mavlink-router/endpoint.cpp
@@ -78,23 +78,25 @@ int Endpoint::handle_read()
     uint8_t src_sysid, src_compid;
     uint32_t msg_id;
     struct buffer buf{};
+    bool crc_valid;
 
     while ((r = read_msg(&buf, &target_sysid, &target_compid, &src_sysid,
-                         &src_compid, &msg_id)) > 0) {
+                         &src_compid, &crc_valid, &msg_id)) > 0) {
         if (allowed_by_filter(msg_id) && allowed_by_dropout())
             Mainloop::get_instance().route_msg(&buf, target_sysid, target_compid,
-                                               src_sysid, src_compid, msg_id);
+                                               src_sysid, src_compid, crc_valid, msg_id);
     }
 
     return r;
 }
 
 int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compid,
-                       uint8_t *src_sysid, uint8_t *src_compid, uint32_t *msg_id)
+                       uint8_t *src_sysid, uint8_t *src_compid, bool *crc_valid, uint32_t *msg_id)
 {
     bool should_read_more = true;
     const mavlink_msg_entry_t *msg_entry;
     uint8_t *payload, seq, payload_len;
+    *crc_valid = false;
 
     if (fd < 0) {
         log_error("Trying to read invalid fd");
@@ -229,12 +231,20 @@ int Endpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compi
          * Ground Station and Flight Stack. Although it can also be a
          * corrupted message is better forward than silent drop it.
          */
-        if (!_check_crc(msg_entry)) {
+        *crc_valid = _check_crc(msg_entry);
+        if (!*crc_valid) {
             _stat.read.crc_error++;
             _stat.read.crc_error_bytes += expected_size;
-            return 0;
+
+            /* In case of a crc error, the message is either corrupt, or the
+             * the definition of the message has been changed in a way that
+             * mavlink router is unaware of. In this case, we treat the message
+             * the same as if we didn't understand the message ID.
+             */
+            msg_entry = nullptr;
+        } else {
+            _add_sys_comp_id(((uint16_t)*src_sysid << 8) | *src_compid);
         }
-        _add_sys_comp_id(((uint16_t)*src_sysid << 8) | *src_compid);
     }
 
     _stat.read.handled++;
@@ -316,7 +326,7 @@ bool Endpoint::has_sys_comp_id(unsigned sys_comp_id)
 }
 
 bool Endpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid,
-                          uint8_t src_compid, uint32_t msg_id)
+                          uint8_t src_compid, bool crc_valid, uint32_t msg_id)
 {
     if (Log::get_max_level() >= Log::Level::DEBUG) {
         log_debug("Endpoint [%d] got message %u to %d/%d from %u/%u", fd, msg_id, target_sysid, target_compid,
@@ -730,9 +740,9 @@ bool UartEndpoint::_change_baud_cb(void *data)
 }
 
 int UartEndpoint::read_msg(struct buffer *pbuf, int *target_sysid, int *target_compid,
-                           uint8_t *src_sysid, uint8_t *src_compid, uint32_t *msg_id)
+                           uint8_t *src_sysid, uint8_t *src_compid, bool *crc_valid, uint32_t *msg_id)
 {
-    int ret = Endpoint::read_msg(pbuf, target_sysid, target_compid, src_sysid, src_compid, msg_id);
+    int ret = Endpoint::read_msg(pbuf, target_sysid, target_compid, src_sysid, src_compid, crc_valid, msg_id);
 
     if (_change_baud_timeout != nullptr && ret == ReadOk) {
         log_info("Baudrate %lu responded, keeping it", _baudrates[_current_baud_idx]);

--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -98,7 +98,7 @@ public:
         return has_sys_comp_id(sys_comp_id);
     }
 
-    bool accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid, uint32_t msg_id);
+    bool accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid, bool crc_valid, uint32_t msg_id);
     void postprocess_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid, uint32_t msg_id);
 
     bool allowed_by_filter(uint32_t msg_id);
@@ -118,7 +118,7 @@ public:
 
 protected:
     virtual int read_msg(struct buffer *pbuf, int *target_system, int *target_compid,
-                         uint8_t *src_sysid, uint8_t *src_compid, uint32_t *msg_id);
+                         uint8_t *src_sysid, uint8_t *src_compid, bool *crc_valid, uint32_t *msg_id);
     virtual ssize_t _read_msg(uint8_t *buf, size_t len) = 0;
     bool _check_crc(const mavlink_msg_entry_t *msg_entry);
     void _add_sys_comp_id(uint16_t sys_comp_id);
@@ -180,7 +180,7 @@ public:
 
 protected:
     int read_msg(struct buffer *pbuf, int *target_system, int *target_compid, uint8_t *src_sysid,
-                 uint8_t *src_compid, uint32_t *msg_id) override;
+                 uint8_t *src_compid, bool *crc_valid, uint32_t *msg_id) override;
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
 
 private:

--- a/src/mavlink-router/logendpoint.cpp
+++ b/src/mavlink-router/logendpoint.cpp
@@ -91,9 +91,12 @@ void LogEndpoint::_send_msg(const mavlink_message_t *msg, int target_sysid)
         0, data
     };
 
+    // Message was created in memory. Assume it's valid.
+    const bool crc_valid = true;
+
     buffer.len = mavlink_msg_to_send_buffer(data, msg);
     Mainloop::get_instance().route_msg(&buffer, target_sysid, MAV_COMP_ID_ALL, msg->sysid,
-                                       msg->compid);
+                                       msg->compid, crc_valid);
 
     _stat.read.total++;
     _stat.read.handled++;
@@ -503,4 +506,8 @@ void LogEndpoint::_handle_auto_start_stop(uint32_t msg_id, uint8_t source_system
             }
         }
     }
+}
+
+bool LogEndpoint::accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid, bool crc_valid, uint32_t msg_id){
+    return crc_valid ? Endpoint::accept_msg(target_sysid, target_compid, src_sysid, src_compid, crc_valid, msg_id) : false;
 }

--- a/src/mavlink-router/logendpoint.h
+++ b/src/mavlink-router/logendpoint.h
@@ -52,6 +52,14 @@ public:
      */
     void mark_unfinished_logs();
 
+    /**
+     * On top of the existing criteria from Endpoints,
+     * LogEndpoints have stricter criteria for accepting a mavlink message.
+     * The CRC checksum must be valid in order to avoid logging corrupt data.
+     * The usual Endpoint criteria for accepting a message are also applied.
+     */
+    bool accept_msg(int target_sysid, int target_compid, uint8_t src_sysid, uint8_t src_compid, bool crc_valid, uint32_t msg_id);
+
 protected:
     const char *_logs_dir;
     int _target_system_id = -1;

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -150,12 +150,12 @@ int Mainloop::write_msg(Endpoint *e, const struct buffer *buf)
 }
 
 void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid, int sender_sysid,
-                         int sender_compid, uint32_t msg_id)
+                         int sender_compid, bool crc_valid, uint32_t msg_id)
 {
     bool unknown = true;
 
     for (const auto& e : _endpoints) {
-        if (e->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id)) {
+        if (e->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, crc_valid, msg_id)) {
             log_debug("Endpoint [%d] accepted message %u to %d/%d from %u/%u", e->fd, msg_id,
                       target_sysid, target_compid, sender_sysid, sender_compid);
             write_msg(e.get(), buf);
@@ -165,7 +165,7 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
     }
 
     for (auto i: _dynamic_endpoints) {
-        if (i.second->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id)) {
+        if (i.second->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, crc_valid, msg_id)) {
             log_debug("Endpoint [%d] accepted message to %d/%d from %u/%u", i.second->fd, target_sysid,
                       target_compid, sender_sysid, sender_compid);
             write_msg(i.second, buf);
@@ -175,7 +175,7 @@ void Mainloop::route_msg(struct buffer *buf, int target_sysid, int target_compid
     }
 
     for (struct endpoint_entry *e = g_tcp_endpoints; e; e = e->next) {
-        if (e->endpoint->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, msg_id)) {
+        if (e->endpoint->accept_msg(target_sysid, target_compid, sender_sysid, sender_compid, crc_valid, msg_id)) {
             log_debug("Endpoint [%d] accepted message %u to %d/%d from %u/%u", e->endpoint->fd, msg_id,
                       target_sysid, target_compid, sender_sysid, sender_compid);
             int r = write_msg(e->endpoint, buf);

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -70,7 +70,7 @@ public:
     int run_single(int timeout_msec);
 
     void route_msg(struct buffer *buf, int target_sysid, int target_compid, int sender_sysid,
-                   int sender_compid, uint32_t msg_id = UINT32_MAX);
+                   int sender_compid, bool crc_valid, uint32_t msg_id = UINT32_MAX);
     void handle_read(Endpoint *e);
     void handle_canwrite(Endpoint *e);
     void handle_tcp_connection();


### PR DESCRIPTION
If a CRC error is encountered, it is either due to corruption or changed message definition of the specific message id. In this case, it is safe to just treat it as an unknown message and route it anyways.