### PR TITLE
Allow returning with an error code, treat TCP connection errors as non-fatal

### DIFF
--- a/src/mavlink-router/endpoint.h
+++ b/src/mavlink-router/endpoint.h
@@ -249,6 +249,7 @@ public:
     }
 
     bool is_valid() override { return _valid; };
+    bool is_critical() override { return false; };
 
 protected:
     ssize_t _read_msg(uint8_t *buf, size_t len) override;

--- a/src/mavlink-router/main.cpp
+++ b/src/mavlink-router/main.cpp
@@ -946,7 +946,7 @@ static void free_endpoints_options_strings(struct options* opts)
 int main(int argc, char *argv[])
 {
     Mainloop mainloop;
-
+    int ret;
     Log::open();
 
     if (!pre_parse_argv(argc, argv)) {
@@ -970,7 +970,7 @@ int main(int argc, char *argv[])
     if (!mainloop.add_endpoints(mainloop, &opt))
         goto endpoint_error;
 
-    mainloop.loop();
+    ret = mainloop.loop();
 
     free_endpoints_options_strings(&opt);
 
@@ -978,7 +978,7 @@ int main(int argc, char *argv[])
 
     Log::close();
 
-    return 0;
+    return ret;
 
 endpoint_error:
     free_endpoints_options_strings(&opt);

--- a/src/mavlink-router/mainloop.cpp
+++ b/src/mavlink-router/mainloop.cpp
@@ -90,8 +90,9 @@ Mainloop& Mainloop::get_instance()
     return *instance;
 }
 
-void Mainloop::request_exit()
+void Mainloop::request_exit(int retcode)
 {
+    _retcode = retcode;
     _should_exit.store(true, std::memory_order_relaxed);
 }
 
@@ -277,10 +278,10 @@ accept_error:
     delete tcp;
 }
 
-void Mainloop::loop()
+int Mainloop::loop()
 {
     if (epollfd < 0)
-        return;
+        return EXIT_FAILURE;
 
     MainloopSignalHandlers handlers(this);
 
@@ -315,6 +316,7 @@ void Mainloop::loop()
         remove_fd(current->fd);
         delete current;
     }
+    return _retcode;
 }
 
 int Mainloop::run_single(int timeout_msec)
@@ -341,7 +343,7 @@ int Mainloop::run_single(int timeout_msec)
         else if (events[i].data.ptr == &g_tcp_fd) {
             if (events[i].events & EPOLLERR) {
                 remove_fd(g_tcp_fd);
-                request_exit();
+                request_exit(EXIT_FAILURE);
             }
             else {
                 handle_tcp_connection();
@@ -364,7 +366,7 @@ int Mainloop::run_single(int timeout_msec)
             }
         }
         if (events[i].events & EPOLLERR) {
-            if (events[i].events & EPOLLHUP) {
+            if (events[i].events & EPOLLHUP || !p->is_critical()) {
                 // EPOLLHUP is an expected error, in case the TCP connection
                 // drops. In this case, we'll just need to clean up the TCP
                 // connection later, no need to panic.
@@ -374,7 +376,7 @@ int Mainloop::run_single(int timeout_msec)
                 remove_fd(p->fd);
                 // make poll errors fatal so that an external component can
                 // restart mavlink-router
-                request_exit();
+                request_exit(EXIT_FAILURE);
             }
         }
     }
@@ -962,7 +964,7 @@ MainloopSignalHandlers::~MainloopSignalHandlers()
 
 void MainloopSignalHandlers::signal_handler_function(int signo)
 {
-    mainloop_instance->request_exit();
+    mainloop_instance->request_exit(0);
 }
 
 Mainloop* MainloopSignalHandlers::mainloop_instance{nullptr};

--- a/src/mavlink-router/mainloop.h
+++ b/src/mavlink-router/mainloop.h
@@ -59,7 +59,7 @@ public:
     int add_fd(int fd, void *data, int events);
     int mod_fd(int fd, void *data, int events);
     int remove_fd(int fd);
-    void loop();
+    int loop();
 
     /*
      * Runs single iteration of mainloop, i.e. single round of event handling.
@@ -100,7 +100,7 @@ public:
      * Request that loop exits "eventually". This (and only this!) function
      * is async-signal safe.
      */
-    void request_exit();
+    void request_exit(int retcode);
 
     /*
      * Expose list of registered endpoints (primarily for direct interaction
@@ -140,6 +140,7 @@ private:
     struct {
         uint32_t msg_to_unknown = 0;
     } _errors_aggregate;
+    int _retcode = 0;
 
     void free_endpoints();
     int tcp_open(unsigned long tcp_port);

--- a/src/mavlink-router/mainloop_test.cpp
+++ b/src/mavlink-router/mainloop_test.cpp
@@ -63,7 +63,7 @@ TEST_F(MainLoopTest, termination)
 {
     Mainloop mainloop;
 
-    mainloop.request_exit();
+    mainloop.request_exit(EXIT_SUCCESS);
 
     mainloop.loop();
 }

--- a/src/mavlink-router/pollable.h
+++ b/src/mavlink-router/pollable.h
@@ -33,4 +33,10 @@ public:
      * from poll.
      */
     virtual bool is_valid() { return true; };
+
+    /**
+     * If a pollable is critical, a poll error will result in
+     * router exit.
+     */
+    virtual bool is_critical() { return true; };
 };


### PR DESCRIPTION
This pretty much adds 

https://github.com/mavlink-router/mavlink-router/commit/70d02acf273b557a227d697570f938b3baa7b63e
https://github.com/mavlink-router/mavlink-router/commit/531a9bd65d20485960195b63bf53c56def5083a2

from upstream.

For us, this means:
- When the mainloop exits, it does so with an error code -> The systemd service actually restarts it
- Errors on TCP connections are generally not fatal, just close those connections. Same handling as upstream