### PR TITLE
fix: always restart mavlink-router

### DIFF
--- a/mavlink-router.service.in
+++ b/mavlink-router.service.in
@@ -4,7 +4,7 @@ Description=MAVLink Router
 [Service]
 Type=simple
 ExecStart=@bindir@/mavlink-routerd
-Restart=on-failure
+Restart=always
 Nice=-20
 
 [Install]


### PR DESCRIPTION
I would like to change the restart policy to "always". This means even if mavlink-router exits with a `0`, systemd will restart it unless stopped through systemd.