### PR TITLE
fix mainloop: do not generally ignore EPOLLHUP

### DIFF
--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -490,7 +490,7 @@ int Mainloop::loop()
             }
 
             if (events[i].events & EPOLLERR) {
-                if (events[i].events & EPOLLHUP || !p->is_critical()) {
+                if (events[i].events & EPOLLHUP && !p->is_critical()) {
                     // EPOLLHUP is an expected error, in case the TCP connection
                     // drops. In this case, we'll just need to clean up the TCP
                     // connection later, no need to panic.


### PR DESCRIPTION
Looking at the code, this logic is only meant for TCP, so should be && and not || (is_critical() is only true for TCP endpoints).

This makes sure that for UARTs, when the device disappears, mavlink-router exits and restarts.
It can happen for example on setups where the autopilot provides a USB serial device, which disconnects when the autopilot reboots.