### PR TITLE
endpoint.cpp: log errors, when reading/writing to TCP/UDP/UART fails

### DIFF
--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -1005,6 +1005,7 @@ ssize_t UartEndpoint::_read_msg(uint8_t *buf, size_t len)
         return 0;
     }
     if (r == -1) {
+        log_error("UART %s: Error reading from uart (%m)", _name.c_str());
         return -errno;
     }
 
@@ -1024,8 +1025,11 @@ int UartEndpoint::write_msg(const struct buffer *pbuf)
     }
 
     ssize_t r = ::write(fd, pbuf->data, pbuf->len);
-    if (r == -1 && errno == EAGAIN) {
-        return -EAGAIN;
+    if (r == -1) {
+        if (errno != EAGAIN) {
+            log_error("UART %s: Error writing to uart (%m)", _name.c_str());
+        }
+        return -errno;
     }
 
     _stat.write.total++;
@@ -1351,6 +1355,7 @@ ssize_t UdpEndpoint::_read_msg(uint8_t *buf, size_t len)
         return 0;
     }
     if (r == -1) {
+        log_error("UDP %s: Error receiving udp packet (%m)", _name.c_str());
         return -errno;
     }
 
@@ -1793,6 +1798,7 @@ ssize_t TcpEndpoint::_read_msg(uint8_t *buf, size_t len)
         return 0;
     }
     if (r == -1) {
+        log_error("TCP %s: Error receiving tcp packet (%m)", _name.c_str());
         return -errno;
     }
 


### PR DESCRIPTION
This introduces two changes:

When the `mavlink-router` fails to send data, it is sometimes hard to debug what exactly caused the issue. One possible cause is that low-level read/write operations failed. This adds some logic to help debugging such issues.

In addition the handling of `UartEndpoint::write_msg` was aligned with the write logic of other endpoints. It will now return with an error in all cases of writing failing.