### PR TITLE
Fix routing bug

### DIFF
--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -251,7 +251,7 @@ int Endpoint::handle_read()
             }
         } else {
             _add_sys_comp_id(buf.curr.src_sysid, buf.curr.src_compid);
-            Mainloop::get_instance().route_msg(&buf);
+            Mainloop::get_instance().route_msg(this, &buf);
         }
     }
 
@@ -522,12 +522,6 @@ Endpoint::AcceptState Endpoint::accept_msg(const struct buffer *pbuf) const
         for (const auto &id : _sys_comp_ids) {
             log_trace("\t\t%u/%u", (id >> 8), id & 0xff);
         }
-    }
-
-    // This endpoint sent the message, we don't want to send it back over the
-    // same channel to avoid loops: reject
-    if (has_sys_comp_id(pbuf->curr.src_sysid, pbuf->curr.src_compid)) {
-        return Endpoint::AcceptState::Rejected;
     }
 
     // If filter is defined and message is not in the set: discard it

--- a/src/logendpoint.cpp
+++ b/src/logendpoint.cpp
@@ -95,7 +95,7 @@ void LogEndpoint::_send_msg(const mavlink_message_t *msg, int target_sysid)
     /* don't bother with it as it's only used by Log backends */
     buffer.curr.payload_len = 0;
 
-    Mainloop::get_instance().route_msg(&buffer);
+    Mainloop::get_instance().route_msg(this, &buffer);
 
     _stat.read.total++;
     _stat.read.handled++;

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -347,7 +347,7 @@ void Mainloop::handle_command_pipe()
                     parse_into_vector(a[10], conf.allow_msg_id_out);
                     parse_into_vector(a[11], conf.block_msg_id_out);
                     parse_into_vector(a[12], conf.allow_src_comp_out);
-                    parse_into_vector(a[14], conf.block_src_comp_out);
+                    parse_into_vector(a[13], conf.block_src_comp_out);
                     parse_into_vector(a[14], conf.allow_src_sys_out);
                     parse_into_vector(a[15], conf.block_src_sys_out);
                     parse_into_vector(a[16], conf.allow_msg_id_in);

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -158,11 +158,14 @@ int Mainloop::write_msg(const std::shared_ptr<Endpoint> &e, const struct buffer 
     return r;
 }
 
-void Mainloop::route_msg(struct buffer *buf)
+void Mainloop::route_msg(Endpoint *src, struct buffer *buf)
 {
     bool unknown = true;
 
     for (const auto &e : this->g_endpoints) {
+        if (e.get() == src)
+            continue; // do not echo to the same endpoint
+
         auto acceptState = e->accept_msg(buf);
 
         switch (acceptState) {

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -59,7 +59,7 @@ public:
     int mod_fd(int fd, void *data, int events) const;
     int remove_fd(int fd) const;
     int loop();
-    void route_msg(struct buffer *buf);
+    void route_msg(Endpoint *src, struct buffer *buf);
     void handle_tcp_connection();
     void handle_command_pipe();
     int write_msg(const std::shared_ptr<Endpoint> &e, const struct buffer *buf) const;


### PR DESCRIPTION
This PR contains two fixes:
1. sysid/compid comparison fails when the same sysid/compid combination is used across two different endpoints in the same group
2. fixed wrong `block_src_comp_out` parameter index