### PR TITLE
tcp: handle unclean tcp connection closing

### DIFF
--- a/src/dedup.h
+++ b/src/dedup.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 class DedupImpl;

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -391,7 +391,6 @@ public:
     int write_msg(const struct buffer *pbuf) override;
     int flush_pending_msgs() override;
     bool is_valid() override { return _valid; };
-    bool is_critical() override { return false; };
 
     Endpoint::AcceptState accept_msg(const struct buffer *pbuf) const override;
 
@@ -405,6 +404,8 @@ public:
     static bool validate_config(const TcpEndpointConfig &config);
 
     void add_no_coalesce_msg_id(uint32_t msg_id) { _coalesce_nodelay.insert(msg_id); }
+
+    void set_invalid() { _valid = false; }
 
 protected:
     bool open(const std::string &ip, unsigned long port);

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -660,7 +660,6 @@ TEST(TcpEndpointTest, Init)
 
     EXPECT_EQ(tcp.get_type(), ENDPOINT_TYPE_TCP);
     EXPECT_TRUE(tcp.is_valid());
-    EXPECT_FALSE(tcp.is_critical());
 
     // we can't call setup() without a TCP server to connect to
 }

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -490,12 +490,18 @@ int Mainloop::loop()
             }
 
             if (events[i].events & EPOLLERR) {
-                if (events[i].events & EPOLLHUP && !p->is_critical()) {
-                    // EPOLLHUP is an expected error, in case the TCP connection
-                    // drops. In this case, we'll just need to clean up the TCP
-                    // connection later, no need to panic.
-                    log_debug("Non-critical error for fd %i.", p->fd);
+                auto tcp_endpoint = dynamic_cast<TcpEndpoint *>(p);
+                if (tcp_endpoint) {
+                    // If we get EPOLLERR for TCP we close the connection.
+                    // If the connection was closed cleanly we also get EPOLLHUP.
+                    tcp_endpoint->set_invalid();
                     should_process_tcp_hangups = true;
+                    if (events[i].events & EPOLLHUP) {
+                        log_debug("Got EPOLLHUP for TCP connection, fd %i.", p->fd);
+                    } else {
+                        log_warning("Poll error for TCP connection, fd %i, closing.", p->fd);
+                    }
+
                 } else {
                     log_error("Critical error for fd %i, exiting", p->fd);
                     request_exit(EXIT_FAILURE);

--- a/src/pollable.h
+++ b/src/pollable.h
@@ -33,10 +33,4 @@ public:
      * from poll.
      */
     virtual bool is_valid() { return true; };
-
-    /**
-     * If a pollable is critical, a poll error will result in
-     * router exit.
-     */
-    virtual bool is_critical() { return true; };
 };


### PR DESCRIPTION
When a TCP connection gets closed uncleanly, poll() does not always return
EPOLLHUP. In that case the router was exiting.
This patch changes the behavior to instead always close the TCP connection
in case of a poll error.

Example script for testing:

```python
import argparse
import random
import socket
import struct
import time

mav_corrupt = bytes.fromhex('fdff0000ffff004242')

messages = [mav_corrupt] * 5

def parse_args():
    parser = argparse.ArgumentParser(description='Send malformed MAVLink messages')
    parser.add_argument('host', type=str, help='IP')
    parser.add_argument('port', type=int, help='port')

    return parser.parse_args()

def main():

    args = parse_args()

    while True:
        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
            print("Connect")
            s.connect((args.host, args.port))

            num_to_send = random.randint(1, 1000)

            for _ in range(num_to_send):
                for msg in messages:
                    s.sendall(msg)

            print("Close")
            # Force an unclean shutdown
            linger_struct = struct.pack('ii', 1, 0)
            s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, linger_struct)
            s.close()
            #return

if __name__ == "__main__":
    # execute only if run as a script
    main()
```