### PR TITLE
Message throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,14 @@ Message coalescing:
     specified. When one of these messages is received, it is added to the UDP
     packet being constructed and sent immediately.
 
+Message throttling:
+  
+  - Some endpoints may require receiving messages at lower rates than the source 
+    sending them (e.g., they are connected over a low-bandwidth link). 
+    The router is capable of throttling specific messages at user defined rates. 
+    To do this, it is sufficient to specify in the config file the list of
+    `<msg_id>,<rate>` pairs under the desired endpoints settings.
+
 Endpoint groups:
 
   - Multiple endpoints can be configured to be in the same endpoin group.

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -218,6 +218,12 @@
 # Default: Empty (no high priority messages)
 # CoalesceNoDelay = 
 
+# List of messages to be throttled to a specified rate (in Hz).
+# Format: Semicolon-separated list of pairs, where each pair consists
+# of an integer and a float, separated by a comma: <msg_id>,<target_rate>
+# Default: Empty (no message throttling)
+#MsgThrottling =
+
 ## Example
 [UartEndpoint alpha]
 Device = /dev/ttyS0

--- a/src/common/conf_file.cpp
+++ b/src/common/conf_file.cpp
@@ -563,6 +563,37 @@ int ConfFile::parse_uint32_vector(const char *val, size_t val_len, void *storage
     return 0;
 }
 
+int ConfFile::parse_pair_vector(const char *val, size_t val_len, void *storage, size_t storage_len)
+{
+    assert(val);
+    assert(storage);
+    assert(val_len);
+
+    std::vector<std::pair<float, float>> *target;
+    if (storage_len < sizeof(*target)) {
+        return -ENOBUFS;
+    }
+
+    char *filter_string = strndupa(val, val_len);
+    target = static_cast<std::vector<std::pair<float, float>> *>(storage);
+    char *token_saveptr, *value_saveptr;
+
+    char *token = strtok_r(filter_string, ";", &token_saveptr);
+    while (token != nullptr) {
+        float first = atof(strtok_r(token, ",", &value_saveptr));
+        char *second_charp = strtok_r(nullptr, ",", &value_saveptr);
+        if (second_charp == nullptr)
+            return -1;
+        float second = atof(second_charp);
+
+        target->push_back(std::pair<float, float>{first, second});
+
+        token = strtok_r(nullptr, ";", &token_saveptr);
+    }
+
+    return 0;
+}
+
 int ConfFile::parse_bool(const char *val, size_t val_len, void *storage, size_t storage_len)
 {
     int ival, ret;

--- a/src/common/conf_file.h
+++ b/src/common/conf_file.h
@@ -124,6 +124,8 @@ public:
                                   size_t storage_len);
     static int parse_uint32_vector(const char *val, size_t val_len, void *storage,
                                    size_t storage_len);
+    static int parse_pair_vector(const char *val, size_t val_len, void *storage,
+                                 size_t storage_len);
 
 #define DECLARE_PARSE_INT(_type) \
     static int parse_##_type(const char *val, size_t val_len, void *storage, size_t storage_len)

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -240,6 +240,12 @@ int Endpoint::handle_read()
 
         // check incoming message filters
         if (!allowed_by_dedup(&buf)) {
+            /*
+             * Even if we discard the message because of de-duplication, we still register
+             * the fact that such (sys_id,comp_id) is reachable through this endpoint
+            */
+            _add_sys_comp_id(buf.curr.src_sysid, buf.curr.src_compid);
+
             if (Log::get_max_level() >= Log::Level::DEBUG) {
                 log_trace("Message %u discarded by de-duplication", buf.curr.msg_id);
             }

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -74,6 +74,7 @@ const ConfFile::OptionsTable UartEndpoint::option_table[] = {
     {"AllowSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, allow_src_sys_in)},
     {"BlockSrcSysIn",   false, ConfFile::parse_uint8_vector,    OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, block_src_sys_in)},
     {"group",           false, ConfFile::parse_stdstring,       OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, group)},
+    {"MsgThrottling",   false, ConfFile::parse_pair_vector,     OPTIONS_TABLE_STRUCT_FIELD(UartEndpointConfig, message_throttling)},
     {}
 };
 
@@ -99,6 +100,7 @@ const ConfFile::OptionsTable UdpEndpoint::option_table[] = {
     {"CoalesceBytes",   false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, coalesce_bytes)},
     {"CoalesceMs",      false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, coalesce_ms)},
     {"CoalesceNoDelay", false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, coalesce_nodelay)},
+    {"MsgThrottling",   false,  ConfFile::parse_pair_vector,    OPTIONS_TABLE_STRUCT_FIELD(UdpEndpointConfig, message_throttling)},
     {}
 };
 
@@ -123,6 +125,7 @@ const ConfFile::OptionsTable TcpEndpoint::option_table[] = {
     {"CoalesceBytes",   false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, coalesce_bytes)},
     {"CoalesceMs",      false,  ConfFile::parse_ul,             OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, coalesce_ms)},
     {"CoalesceNoDelay", false,  ConfFile::parse_uint32_vector,  OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, coalesce_nodelay)},
+    {"MsgThrottling",   false,  ConfFile::parse_pair_vector,    OPTIONS_TABLE_STRUCT_FIELD(TcpEndpointConfig, message_throttling)},
     {}
 };
 // clang-format on
@@ -566,6 +569,11 @@ Endpoint::AcceptState Endpoint::accept_msg(const struct buffer *pbuf) const
         return Endpoint::AcceptState::Filtered;
     }
 
+    // If throttling is enabled and message is too frequent
+    if (is_throttling_enabled(pbuf) && should_throttle_msg(pbuf)) {
+        return Endpoint::AcceptState::Throttled;
+    }
+
     // Message is broadcast on sysid or sysid is non-existent: accept msg
     if (pbuf->curr.target_sysid == 0 || pbuf->curr.target_sysid == -1) {
         return Endpoint::AcceptState::Accepted;
@@ -590,6 +598,42 @@ Endpoint::AcceptState Endpoint::accept_msg(const struct buffer *pbuf) const
 
     // Reject everything else
     return Endpoint::AcceptState::Rejected;
+}
+
+bool Endpoint::is_throttling_enabled(const struct buffer *pbuf) const
+{
+    // Check if message throttling is enabled for such message id
+    return pbuf->curr.msg_id != UINT32_MAX && !_message_throttle_map.empty()
+        && _message_throttle_map.count(pbuf->curr.msg_id);
+}
+
+bool Endpoint::should_throttle_msg(const struct buffer *pbuf) const
+{
+    const throttle_info &thr_info = _message_throttle_map.at(pbuf->curr.msg_id);
+    if (thr_info.rate < FLT_EPSILON)
+        return false; // invalid rate or throttling disabled
+
+    const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+    if (now < thr_info.next_timestamp)
+        return true;
+
+    return false;
+}
+
+void Endpoint::update_throttle_info(const struct buffer *pbuf)
+{
+    throttle_info &thr_info = _message_throttle_map.at(pbuf->curr.msg_id);
+    const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+    const auto period = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::duration<float>(1.f / thr_info.rate));
+
+    // We haven't received any new message in a while: reset next timestamp
+    if (now > thr_info.next_timestamp + 2 * period) {
+        thr_info.next_timestamp = now;
+    }
+
+    // Compute next timestamp
+    thr_info.next_timestamp += period;
 }
 
 bool Endpoint::allowed_by_dedup(const buffer *buf) const
@@ -808,6 +852,16 @@ bool UartEndpoint::setup(UartEndpointConfig conf)
     }
 
     this->_group_name = conf.group;
+
+    // Message throttling config
+    for (auto throttle_cfg : conf.message_throttling) {
+        if (throttle_cfg.first > UINT32_MAX) {
+            return false;
+        }
+
+        uint32_t msg_id = static_cast<uint32_t>(throttle_cfg.first);
+        this->set_message_throttling(msg_id, throttle_cfg.second);
+    }
 
     return true;
 }
@@ -1165,6 +1219,16 @@ bool UdpEndpoint::setup(UdpEndpointConfig conf)
     this->_coalesce_ms = conf.coalesce_ms;
     for (auto msg_id : conf.coalesce_nodelay) {
         this->add_no_coalesce_msg_id(msg_id);
+    }
+
+    // Message throttling config
+    for (auto throttle_cfg : conf.message_throttling) {
+        if (throttle_cfg.first > UINT32_MAX) {
+            return false;
+        }
+
+        uint32_t msg_id = static_cast<uint32_t>(throttle_cfg.first);
+        this->set_message_throttling(msg_id, throttle_cfg.second);
     }
 
     return true;
@@ -1630,6 +1694,16 @@ bool TcpEndpoint::setup(TcpEndpointConfig conf)
     this->_coalesce_ms = conf.coalesce_ms;
     for (auto msg_id : conf.coalesce_nodelay) {
         this->add_no_coalesce_msg_id(msg_id);
+    }
+
+    // Message throttling config
+    for (auto throttle_cfg : conf.message_throttling) {
+        if (throttle_cfg.first > UINT32_MAX) {
+            return false;
+        }
+
+        uint32_t msg_id = static_cast<uint32_t>(throttle_cfg.first);
+        this->set_message_throttling(msg_id, throttle_cfg.second);
     }
 
     if (!this->open(conf.address, conf.port)) {

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -20,9 +20,12 @@
 #include <common/conf_file.h>
 #include <common/mavlink.h>
 
+#include <cfloat>
+#include <chrono>
 #include <memory>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -55,6 +58,7 @@ struct UartEndpointConfig {
     std::vector<uint8_t> allow_src_sys_in;
     std::vector<uint8_t> block_src_sys_in;
     std::string group;
+    std::vector<std::pair<float, float>> message_throttling;
 };
 
 struct UdpEndpointConfig {
@@ -80,6 +84,7 @@ struct UdpEndpointConfig {
     unsigned long coalesce_bytes;
     unsigned long coalesce_ms;
     std::vector<uint32_t> coalesce_nodelay;
+    std::vector<std::pair<float, float>> message_throttling;
 };
 
 struct TcpEndpointConfig {
@@ -103,6 +108,7 @@ struct TcpEndpointConfig {
     unsigned long coalesce_bytes;
     unsigned long coalesce_ms;
     std::vector<uint32_t> coalesce_nodelay;
+    std::vector<std::pair<float, float>> message_throttling;
 };
 
 /*
@@ -159,6 +165,7 @@ public:
         Accepted = 1,
         Filtered,
         Rejected,
+        Throttled,
     };
 
     Endpoint(std::string type, std::string name);
@@ -185,6 +192,12 @@ public:
     }
 
     AcceptState virtual accept_msg(const struct buffer *pbuf) const;
+
+    bool is_throttling_enabled(const struct buffer *pbuf) const;
+
+    bool should_throttle_msg(const struct buffer *pbuf) const;
+
+    void update_throttle_info(const struct buffer *pbuf);
 
     void filter_add_allowed_out_msg_id(uint32_t msg_id)
     {
@@ -233,6 +246,15 @@ public:
     void filter_add_blocked_in_src_sys(uint8_t src_sys)
     {
         _blocked_incoming_src_systems.push_back(src_sys);
+    }
+
+    void set_message_throttling(uint32_t msg_id, float rate)
+    {
+        if (rate > FLT_EPSILON) { // add the msg_id to the throttle map
+            _message_throttle_map[msg_id].rate = rate;
+        } else { // un-throttle by removing the entry from the map
+            _message_throttle_map.erase(msg_id);
+        }
     }
 
     bool allowed_by_dedup(const buffer *pbuf) const;
@@ -298,6 +320,12 @@ private:
     std::vector<uint8_t> _blocked_incoming_src_comps;
     std::vector<uint8_t> _allowed_incoming_src_systems;
     std::vector<uint8_t> _blocked_incoming_src_systems;
+
+    typedef struct {
+        float rate;
+        std::chrono::steady_clock::time_point next_timestamp = std::chrono::steady_clock::now();
+    } throttle_info;
+    std::unordered_map<uint32_t, throttle_info> _message_throttle_map;
 };
 
 class UartEndpoint : public Endpoint {

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -177,6 +177,12 @@ void Mainloop::route_msg(struct buffer *buf)
             if (write_msg(e, buf) == -EPIPE) { // only TCP endpoints should return -EPIPE
                 should_process_tcp_hangups = true;
             }
+
+            // Update throttling time info if the mechanism is enabled on this endpoint
+            if (e->is_throttling_enabled(buf)) {
+                e->update_throttle_info(buf);
+            }
+
             unknown = false;
             break;
         case Endpoint::AcceptState::Filtered:
@@ -187,6 +193,18 @@ void Mainloop::route_msg(struct buffer *buf)
                       buf->curr.target_compid,
                       buf->curr.src_sysid,
                       buf->curr.src_compid);
+            unknown = false;
+            break;
+        case Endpoint::AcceptState::Throttled:
+            // Discard the message for throttling reasons
+            log_trace(
+                "Endpoint [%d] discarded message %u to %d/%d from %u/%u for throttling reasons",
+                e->fd,
+                buf->curr.msg_id,
+                buf->curr.target_sysid,
+                buf->curr.target_compid,
+                buf->curr.src_sysid,
+                buf->curr.src_compid);
             unknown = false;
             break;
         case Endpoint::AcceptState::Rejected:
@@ -411,6 +429,33 @@ void Mainloop::handle_command_pipe()
                     // Remove from endpoint list
                     g_endpoints.erase(to_delete);
                     log_info("Removed endpoint %s", a[1].c_str());
+                }
+            } else if (a[0] == "throttle") {
+                // Throttle command
+                // throttle Name msg_id rate
+                //    a0     a1    a2    a3
+
+                // Sanity checks
+                if (a.size() != 4) {
+                    log_error("Command Server: throttle command usage: \n\tthrottle "
+                              "<endpoint_name> <msg_id> <rate>");
+                    continue;
+                }
+
+                auto to_update = std::find_if(
+                    g_endpoints.begin(),
+                    g_endpoints.end(),
+                    [&a](const std::shared_ptr<Endpoint> e) { return e->get_name() == a[1]; });
+
+                if (to_update == g_endpoints.end()) {
+                    log_error("No endpoint named %s", a[1].c_str());
+                } else {
+                    to_update->get()->set_message_throttling(atol(a[2].c_str()),
+                                                             atof(a[3].c_str()));
+                    log_info("Endpoint %s: updated message %s rate to %sHz",
+                             a[1].c_str(),
+                             a[2].c_str(),
+                             a[3].c_str());
                 }
 
             } else {


### PR DESCRIPTION
## Description
This PR adds message throttling feature in mavlink-router: the router will drop messages of a given topic to comply with the requested maximum rate.
Message throttling can be configured per endpoint by adding the `MsgThrottling =` configuration field. Such field is a list of pairs composed by `<msg_id>,<desired_rate>`.
For example, the config `MsgThrottling = 30,3.0; 33,7.3` will throttle topic `ATTITUDE` (id 30) to 3Hz and will throttle `GLOBAL_POSITION_INT` (id 33) to 7.3Hz. All the remaining messages are routed un-throttled.

## Limitation
The router throttles streams by dropping messages, thus throttling any critical topic (any topic that we cannot afford to lose any packet) will break such protocol. (e.g. parameters, mavftp, mission, ...). That will be solved by a future PR with cached throttling.

## Testing
A quick way to test is by using PX4 sitl and AMC/QCG:
- Run PX4 sitl with `make px4_sitl_default gz_x500`
- Run mavlink router with `./mavlink-routerd -c router.conf` where `router.conf` is:

```
[General]
DebugLogLevel = debug

[UdpEndpoint GCS]
Mode = Normal
Address = 127.0.0.1
Port = 10020
MsgThrottling = 30,3.0; 33,7.3

[UdpEndpoint PX4]
Mode = Server
Address = 127.0.0.1
Port = 14550
```
- Run AMC/QGC and connect to the router by creating a new comm link listening on UDP port `10020`
- Check in mavlink inspector that topics `ATTITUDE` (id 30) and `GLOBAL_POSITION_INT` (id 33) are indeed published at the rates set in the router config.