### PR TITLE
Race condition in test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,13 +49,13 @@ jobs:
               sudo apt-get install --yes libgtest-dev
           fi
           sudo apt-get install --yes pkg-config gcc-multilib g++-multilib ninja-build python3-pip
-          pip3 install meson pymavlink
+          pip3 install meson pymavlink psutil
       - name: install dependencies (cross)
         if: ${{ matrix.arch != 'native' }}
         run: |
           sudo apt-get update
           sudo apt-get install --yes ninja-build gcc-${{ matrix.arch }} g++-${{ matrix.arch }} podman python3-pip
-          pip3 install meson pymavlink
+          pip3 install meson pymavlink psutil
 
       - name: prepare sysroot
         if: ${{ matrix.arch != 'native' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,10 +109,10 @@ jobs:
           overwrite: true
 
   alpine-linux:
-    name: alpine 3.14 (musl)
+    name: alpine 3.16 (musl)
     runs-on: ubuntu-24.04
     needs: [formatting-check]
-    container: alpine:3.14
+    container: alpine:3.16
     steps:
       - name: install dependencies
         run: apk update && apk add build-base git linux-headers pkgconf meson ninja

--- a/tests/routing_test.py
+++ b/tests/routing_test.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 import time
 from pymavlink import mavutil
+import psutil
 
 SENDER_NUM_MESSAGES = 10
 
@@ -116,6 +117,12 @@ def expect_len(name, msgs, expected):
     return True
 
 
+def is_udp_port_bound(port):
+    for conn in psutil.net_connections(kind='udp'):
+        if conn.laddr.port == port:
+            return True
+    return False
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='MAVLink Router Message Routing System Test')
@@ -132,6 +139,10 @@ if __name__ == "__main__":
     ],
                           stderr=sys.stdout.fileno(),
                           stdout=sys.stdout.fileno()) as proc:
+        
+        # Wait for mavlink router to start (for it to bind socket 127.0.0.1:10000)
+        while not is_udp_port_bound(10000):
+            time.sleep(0.2)
 
         # Two senders: one send to all (target 0). The other sends to target 100/1
         sender0 = MavlinkSender("sender0", 10000, 1, 1, 0, 0)


### PR DESCRIPTION
## Issue
Based on the state of the CI runner executing the test  `routing_test.py` it can be that the MavlinkSender objects (`sender0` and `sender100` start sending packets to the router before the router is even fully started, causing the entire test to fail because the expected number of received packets doesn't match.
<img width="1821" height="265" alt="Screenshot from 2026-03-19 10-42-54" src="https://github.com/user-attachments/assets/4825b4e0-8941-41dc-8ce8-17ff714faf01" />
In the wireshark screenshot you can see that the first 2 `PING` messages are lost because socket `127.0.0.1:10000` is not reachable yet.

Another issue is the deprecated Alpine container which causes the alpine build to always fail.

## Solution
After starting the router wait till udp port `10000` is bound meaning that the router is ready to receive messages. After that we can start the MavlinkSender objects and the receivers.

Update the Alpine docker container to `3.16`.