### PR TITLE
feat: ip4 multicast support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           clang-format-version: "13"
           check-path: "src"
+          style: file
 
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           clang-format-version: "13"
           check-path: "src"
-          style: file
 
   build:
     runs-on: ubuntu-24.04

--- a/examples/config.sample
+++ b/examples/config.sample
@@ -246,6 +246,8 @@ Baud = 52000
 # Binding or target IP address (depending on mode).
 # IPv6 addresses must be encosed in square brackets like `[::1]`.
 # Binding to `0.0.0.0` or `[::]` will listen on all interfaces.
+# If a multicast address is specified (224.0.0.0 - 239.255.255.255) in server
+# mode, mavlink-router will automatically join that multicast group.
 # Mandatory, no default value
 #Address = 
 
@@ -270,6 +272,12 @@ Port = 10000
 Mode = Normal
 Address = 127.0.0.1
 Port = 11000
+
+# join multicast group 239.255.145.50 on port 14550
+[UdpEndpoint multicast_example]
+Mode = Server
+Address = 239.255.145.50
+Port = 14550
 
 
 ##

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -148,6 +148,12 @@ static bool ipv6_is_multicast(const char *ip)
     return strncmp(ip, "ff0", 3) == 0;
 }
 
+static bool ipv4_is_multicast(in_addr_t addr)
+{
+    /* multicast addresses are in range 224.0.0.0 - 239.255.255.255 (0xE0000000 - 0xEFFFFFFF) */
+    return (ntohl(addr) & 0xF0000000) == 0xE0000000;
+}
+
 static bool validate_ipv6(const std::string &ip)
 {
     // simplyfied pattern
@@ -1314,11 +1320,44 @@ int UdpEndpoint::open_ipv4(const char *ip, unsigned long port, UdpEndpointConfig
     sockaddr.sin_addr.s_addr = inet_addr(ip);
     sockaddr.sin_port = htons(port);
 
+    const bool is_multicast = ipv4_is_multicast(sockaddr.sin_addr.s_addr);
+    in_addr_t multicast_addr = 0;
+
     if (mode == UdpEndpointConfig::Mode::Server || mode == UdpEndpointConfig::Mode::Receiver) {
+        if (is_multicast) {
+            // Save multicast address before modifying sockaddr for bind
+            multicast_addr = sockaddr.sin_addr.s_addr;
+
+            // Enable address reuse for multicast (allows multiple subscribers)
+            const int reuse_val = 1;
+            if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuse_val, sizeof(reuse_val)) < 0) {
+                log_error("Error setting SO_REUSEADDR for %s:%lu (%m)", ip, port);
+                goto fail;
+            }
+
+            // Multicast requires binding to INADDR_ANY
+            sockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
+        }
+
         if (bind(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) < 0) {
             log_error("Error binding IPv4 socket for %s:%lu (%m)", ip, port);
             goto fail;
         }
+
+        if (is_multicast) {
+            // Join the multicast group
+            struct ip_mreq mreq = {};
+            mreq.imr_multiaddr.s_addr = multicast_addr;
+            mreq.imr_interface.s_addr = htonl(INADDR_ANY);
+
+            if (setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) < 0) {
+                log_error("Error joining multicast group %s (%m)", ip);
+                goto fail;
+            }
+
+            log_info("Joined multicast group %s", ip);
+        }
+
         sockaddr.sin_port = 0;
     }
 

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -651,6 +651,46 @@ TEST(UdpEndpointTest, ConfigValidateMode)
     EXPECT_FALSE(UdpEndpoint::validate_config(config)) << "with Undefined mode";
 }
 
+TEST(UdpEndpointTest, ConfigValidateMulticastAddress)
+{
+    UdpEndpointConfig config;
+    config.port = 14550;
+    config.mode = UdpEndpointConfig::Mode::Server;
+
+    // valid multicast addresses (224.0.0.0 - 239.255.255.255)
+    config.address = "224.0.0.1";
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with multicast address " << config.address;
+
+    config.address = "239.255.255.250";
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with multicast address " << config.address;
+
+    config.address = "239.255.145.50";
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with multicast address " << config.address;
+
+    // valid unicast addresses (for comparison)
+    config.address = "192.168.1.1";
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with unicast address " << config.address;
+
+    config.address = "0.0.0.0";
+    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with bind-all address " << config.address;
+}
+
+TEST(UdpEndpointTest, MulticastServerSetup)
+{
+    // Mainloop is already initialized by UdpEndpointTest.Init
+    UdpEndpoint udp{"multicast_test"};
+
+    UdpEndpointConfig config;
+    config.name = "multicast_test";
+    config.address = "239.255.145.50";
+    config.port = 14550;
+    config.mode = UdpEndpointConfig::Mode::Server;
+
+    // Setup should succeed - joins multicast group
+    EXPECT_TRUE(udp.setup(config)) << "Failed to setup multicast UDP endpoint";
+    EXPECT_TRUE(udp.is_valid()) << "Multicast endpoint should be valid after setup";
+}
+
 /**
  * TCP Endpoint
  */

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -34,8 +34,9 @@
 // Create custom inhertited class b/c Endpoint can't be initialized containing pure virtual methods
 class TestEndpoint : public Endpoint {
 public:
-  TestEndpoint() : Endpoint{"Test", "foobar"} {};
-  ~TestEndpoint() override {};
+    TestEndpoint()
+        : Endpoint{"Test", "foobar"} {};
+    ~TestEndpoint() override{};    // dummy-implement virtual methods
 
     // dummy-implement virtual methods
     int write_msg(const struct buffer *pbuf) override { return true; };

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -36,7 +36,7 @@ class TestEndpoint : public Endpoint {
 public:
     TestEndpoint()
         : Endpoint{"Test", "foobar"} {};
-    ~TestEndpoint() override{};    // dummy-implement virtual methods
+    ~TestEndpoint() override {};
 
     // dummy-implement virtual methods
     int write_msg(const struct buffer *pbuf) override { return true; };

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -36,7 +36,7 @@ class TestEndpoint : public Endpoint {
 public:
     TestEndpoint()
         : Endpoint{"Test", "foobar"} {};
-    ~TestEndpoint() override {};
+    ~TestEndpoint() override{};
 
     // dummy-implement virtual methods
     int write_msg(const struct buffer *pbuf) override { return true; };

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -34,9 +34,8 @@
 // Create custom inhertited class b/c Endpoint can't be initialized containing pure virtual methods
 class TestEndpoint : public Endpoint {
 public:
-    TestEndpoint()
-        : Endpoint{"Test", "foobar"} { };
-    ~TestEndpoint() override { };
+  TestEndpoint() : Endpoint{"Test", "foobar"} {};
+  ~TestEndpoint() override {};
 
     // dummy-implement virtual methods
     int write_msg(const struct buffer *pbuf) override { return true; };

--- a/src/endpoints_test.cpp
+++ b/src/endpoints_test.cpp
@@ -35,8 +35,8 @@
 class TestEndpoint : public Endpoint {
 public:
     TestEndpoint()
-        : Endpoint{"Test", "foobar"} {};
-    ~TestEndpoint() override{};
+        : Endpoint{"Test", "foobar"} { };
+    ~TestEndpoint() override { };
 
     // dummy-implement virtual methods
     int write_msg(const struct buffer *pbuf) override { return true; };
@@ -659,13 +659,16 @@ TEST(UdpEndpointTest, ConfigValidateMulticastAddress)
 
     // valid multicast addresses (224.0.0.0 - 239.255.255.255)
     config.address = "224.0.0.1";
-    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with multicast address " << config.address;
+    EXPECT_TRUE(UdpEndpoint::validate_config(config))
+        << "with multicast address " << config.address;
 
     config.address = "239.255.255.250";
-    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with multicast address " << config.address;
+    EXPECT_TRUE(UdpEndpoint::validate_config(config))
+        << "with multicast address " << config.address;
 
     config.address = "239.255.145.50";
-    EXPECT_TRUE(UdpEndpoint::validate_config(config)) << "with multicast address " << config.address;
+    EXPECT_TRUE(UdpEndpoint::validate_config(config))
+        << "with multicast address " << config.address;
 
     // valid unicast addresses (for comparison)
     config.address = "192.168.1.1";


### PR DESCRIPTION
# Add IPv4 UDP Multicast Support

## Summary

This PR adds support for IPv4 UDP multicast addresses in server mode, enabling mavlink-router to join multicast groups and receive MAVLink messages from multiple senders on the network.

## Changes

- **Multicast detection**: Added `ipv4_is_multicast()` function to detect addresses in the 224.0.0.0 - 239.255.255.255 range
- **Socket configuration**: When a multicast address is specified in server mode:
  - Sets `SO_REUSEADDR` to allow multiple subscribers on the same port
  - Binds to `INADDR_ANY` (required for multicast)
  - Joins the multicast group via `IP_ADD_MEMBERSHIP`
- **Tests**: Added unit tests for multicast address validation and endpoint setup
- **Documentation**: Updated `config.sample` with multicast usage example

## Usage

```ini
[UdpEndpoint multicast_example]
Mode = Server
Address = 239.255.145.50
Port = 14550
```
