### PR TITLE
Buffer UART writes

### DIFF
--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -1464,8 +1464,18 @@ ssize_t UdpEndpoint::_read_msg(uint8_t *buf, size_t len)
     return r;
 }
 
+bool UdpEndpoint::_has_peer() const
+{
+    return this->is_ipv6 ? sockaddr6.sin6_port != 0 : sockaddr.sin_port != 0;
+}
+
 int UdpEndpoint::write_msg(const struct buffer *pbuf)
 {
+    if (!_has_peer()) {
+        log_trace("UDP %s: No one ever connected to us. No one to write for", _name.c_str());
+        return 0;
+    }
+
     // We cannot add the new message to the coalescence or to the tx buffer -> send immediately what is scheduled
     if (tx_buf.len > 0 && tx_buf.len + pbuf->len > _coalesce_bytes) {
         log_trace("New message would overflow the coalescence, sending the pending ones before");
@@ -1535,19 +1545,17 @@ int UdpEndpoint::flush_pending_msgs()
         return -EINVAL;
     }
 
-    bool sock_connected = false;
     if (this->is_ipv6) {
         addrlen = sizeof(sockaddr6);
         sock = (struct sockaddr *)&sockaddr6;
-        sock_connected = sockaddr6.sin6_port != 0;
     } else {
         addrlen = sizeof(sockaddr);
         sock = (struct sockaddr *)&sockaddr;
-        sock_connected = sockaddr.sin_port != 0;
     }
 
-    if (!sock_connected) {
+    if (!_has_peer()) {
         log_trace("UDP %s: No one ever connected to us. No one to write for", _name.c_str());
+        tx_buf.len = 0;
         return 0;
     }
 

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -1473,8 +1473,9 @@ int UdpEndpoint::write_msg(const struct buffer *pbuf)
     }
 
     if (tx_buf.len + pbuf->len > TX_BUF_MAX_SIZE) {
-        log_trace("Dropping message, tx buffer full");
-        return 0;
+        _dropped_msgs++;
+        log_trace("UDP %s: Dropping message, tx buffer full", _name.c_str());
+        return -ENOBUFS;
     }
 
     // Append new data in the tx buffer
@@ -1932,8 +1933,9 @@ int TcpEndpoint::write_msg(const struct buffer *pbuf)
     }
 
     if (tx_buf.len + pbuf->len > TX_BUF_MAX_SIZE) {
-        log_trace("Dropping message, tx buffer full");
-        return 0;
+        _dropped_msgs++;
+        log_trace("TCP %s: Dropping message, tx buffer full", _name.c_str());
+        return -ENOBUFS;
     }
 
     // Append new data in the tx buffer

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -224,7 +224,11 @@ Endpoint::~Endpoint()
 bool Endpoint::handle_canwrite()
 {
     int r = flush_pending_msgs();
-    return r == -EAGAIN;
+
+    // A short write leaves the rest of the backlog queued, so keep EPOLLOUT armed for it.
+    // If the flush ever returns 0 on a non-empty buffer, the fd stays writable,
+    // thus EPOLLOUT re-fires every iteration and we busy loop
+    return r == -EAGAIN || (r > 0 && tx_buf.len > 0);
 }
 
 int Endpoint::handle_read()

--- a/src/endpoint.cpp
+++ b/src/endpoint.cpp
@@ -780,14 +780,14 @@ uint8_t Endpoint::get_trimmed_zeros(const mavlink_msg_entry_t *msg_entry,
 
 void Endpoint::log_aggregate(unsigned int interval_sec)
 {
-    if (_incomplete_msgs > 0) {
-        log_warning("%s Endpoint [%d]%s: %u incomplete messages in the last %d seconds",
+    if (_dropped_msgs > 0) {
+        log_warning("%s Endpoint [%d]%s: %u dropped messages in the last %d seconds",
                     _type.c_str(),
                     fd,
                     _name.c_str(),
-                    _incomplete_msgs,
+                    _dropped_msgs,
                     interval_sec);
-        _incomplete_msgs = 0;
+        _dropped_msgs = 0;
     }
 }
 
@@ -1083,12 +1083,41 @@ int UartEndpoint::write_msg(const struct buffer *pbuf)
         return -EINVAL;
     }
 
-    /* TODO: send any pending data */
-    if (tx_buf.len > 0) {
-        ;
+    if (tx_buf.len + pbuf->len > TX_BUF_MAX_SIZE) {
+        _dropped_msgs++;
+        log_trace("UART %s: Dropping message, tx buffer full", _name.c_str());
+        return -ENOBUFS;
     }
 
-    ssize_t r = ::write(fd, pbuf->data, pbuf->len);
+    // Append to the tx buffer
+    memcpy(&tx_buf.data[tx_buf.len], pbuf->data, pbuf->len);
+    tx_buf.len += pbuf->len;
+
+    _stat.write.total++;
+
+    // Try to flush the buffer immediately, if it does not empty the buffer
+    // return -EAGAIN so the mainloop will arm EPOLLOUT
+    int ret = flush_pending_msgs();
+    if (ret > 0 && tx_buf.len > 0) {
+        return -EAGAIN;
+    }
+
+    return ret;
+}
+
+int UartEndpoint::flush_pending_msgs()
+{
+    if (tx_buf.len == 0) {
+        log_trace("No data in tx buffer, skipping write");
+        return 0;
+    }
+
+    if (fd < 0) {
+        log_error("UART %s: Trying to write invalid fd", _name.c_str());
+        return -EINVAL;
+    }
+
+    ssize_t r = ::write(fd, tx_buf.data, tx_buf.len);
     if (r == -1) {
         if (errno != EAGAIN) {
             log_error("UART %s: Error writing to uart (%m)", _name.c_str());
@@ -1096,19 +1125,13 @@ int UartEndpoint::write_msg(const struct buffer *pbuf)
         return -errno;
     }
 
-    _stat.write.total++;
-    _stat.write.bytes += pbuf->len;
+    _stat.write.bytes += r;
 
-    /* Incomplete packet, we warn and discard the rest */
-    if (r != (ssize_t)pbuf->len) {
-        _incomplete_msgs++;
-        log_debug("UART %s: Discarding packet, incomplete write %zd but len=%u",
-                  _name.c_str(),
-                  r,
-                  pbuf->len);
-    }
+    tx_buf.len = std::max(ssize_t(0), (ssize_t)tx_buf.len - r);
+    // memcpy isn't safe for overlapping regions
+    memmove(tx_buf.data, &tx_buf.data[r], tx_buf.len);
 
-    log_trace("UART [%d]%s: Wrote %zd bytes", fd, _name.c_str(), r);
+    log_trace("UART [%d]%s: Wrote %zd bytes, %u pending", fd, _name.c_str(), r, tx_buf.len);
 
     return r;
 }

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -385,6 +385,7 @@ protected:
     int open_ipv6(const char *ip, unsigned long port, UdpEndpointConfig::Mode mode);
 
     ssize_t _read_msg(uint8_t *buf, size_t len) override;
+    bool _has_peer() const;
 
     union {
         struct sockaddr_in v4;

--- a/src/endpoint.h
+++ b/src/endpoint.h
@@ -304,7 +304,7 @@ protected:
         } write;
     } _stat;
 
-    uint32_t _incomplete_msgs = 0;
+    uint32_t _dropped_msgs = 0;
     std::vector<uint16_t> _sys_comp_ids;
 
 private:
@@ -334,7 +334,7 @@ public:
     ~UartEndpoint() override = default;
 
     int write_msg(const struct buffer *pbuf) override;
-    int flush_pending_msgs() override { return -ENOSYS; }
+    int flush_pending_msgs() override;
 
     bool setup(UartEndpointConfig config); ///< open UART device and apply config
 

--- a/src/mainloop.cpp
+++ b/src/mainloop.cpp
@@ -148,10 +148,10 @@ int Mainloop::write_msg(const std::shared_ptr<Endpoint> &e, const struct buffer 
     int r = e->write_msg(buf);
 
     /*
-     * If endpoint would block, add EPOLLOUT event to get notified when it's
-     * possible to write again
+     * If the endpoint would block, or its tx buffer is already full, arm EPOLLOUT
+     * event to get notified when it's possible to write again
      */
-    if (r == -EAGAIN) {
+    if (r == -EAGAIN || r == -ENOBUFS) {
         mod_fd(e->fd, e.get(), EPOLLIN | EPOLLOUT);
     }
 


### PR DESCRIPTION
This PR introduces/fixes the following:
- despite having a tx buffer, the UART endpoint wrote straight to the fd. Messages now queue in `tx_buf` and are flushed as a whole. This way the UART Endpoints follow the same logic as the UDP and TCP endpoints to be more consistent in the codebase
- instead of arming `EPOLLOUT` only on `-EAGAIN`, keep `EPOLLOUT` armed while data is pending (tx buffer not empty). This way we prevent the possibility that short write disarmed `EPOLLOUT` and leaving the rest of the backlog in the tx_buffer until the next message came
- don't queue messages in an UDPEndpoint (server or listener) with no peer